### PR TITLE
Task/COOKS-34: Allows users to select map feature

### DIFF
--- a/client/src/components/ProTx/components/charts/MainChart.js
+++ b/client/src/components/ProTx/components/charts/MainChart.js
@@ -1,13 +1,38 @@
 import React from 'react';
 import './MainChart.css';
+import PropTypes from 'prop-types';
 import ScatterBarChart from './ScatterBarChart';
 
-function MainChart() {
+function MainChart({
+  mapType,
+  geography,
+  maltreatmentTypes,
+  observedFeature,
+  year,
+  selectedGeographicFeature,
+  data
+}) {
+  const selectedFeatureInfo = selectedGeographicFeature || 'NONE';
   return (
     <div className="main-chart">
+      <span style={{ color: 'red' }}>
+        mapType: {mapType} geography: {} year: {year} selected feature:{' '}
+        {selectedFeatureInfo}
+      </span>
       <ScatterBarChart className="chart-diagram" />
     </div>
   );
 }
+
+MainChart.propTypes = {
+  mapType: PropTypes.string.isRequired,
+  geography: PropTypes.string.isRequired,
+  maltreatmentTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
+  observedFeature: PropTypes.string.isRequired,
+  year: PropTypes.string.isRequired,
+  selectedGeographicFeature: PropTypes.string.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  data: PropTypes.object.isRequired
+};
 
 export default MainChart;

--- a/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
+++ b/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
@@ -8,6 +8,7 @@ import { MALTREATMENT, OBSERVED_FEATURES } from '../meta';
 
 function DashboardDisplay() {
   // Map type and selected types (i.e. geography, year etc)
+  // TODO: control of this state should be moved to redux/sagas (https://jira.tacc.utexas.edu/browse/COOKS-55)
   const [mapType, setMapType] = useState('maltreatment');
   const [geography, setGeography] = useState('county');
   const [maltreatmentTypes, setMaltreatmentTypes] = useState([
@@ -17,6 +18,9 @@ function DashboardDisplay() {
     OBSERVED_FEATURES[0].field
   );
   const [year, setYear] = useState('2019');
+  const [selectedGeographicFeature, setSelectedGeographicFeature] = useState(
+    null
+  );
 
   const dispatch = useDispatch();
   const { loading, error, data } = useSelector(state => state.protx);
@@ -65,6 +69,8 @@ function DashboardDisplay() {
         observedFeature={observedFeature}
         year={year}
         data={data}
+        selectedGeographicFeature={selectedGeographicFeature}
+        setSelectedGeographicFeature={setSelectedGeographicFeature}
       />
     </div>
   );

--- a/client/src/components/ProTx/components/dashboard/DisplayLayout.js
+++ b/client/src/components/ProTx/components/dashboard/DisplayLayout.js
@@ -10,12 +10,22 @@ function DisplayLayout({
   maltreatmentTypes,
   observedFeature,
   year,
+  selectedGeographicFeature,
+  setSelectedGeographicFeature,
   data
 }) {
   return (
     <div className="display-layout-root">
       <div className="chart-layout">
-        <MainChart />
+        <MainChart
+          mapType={mapType}
+          geography={geography}
+          maltreatmentTypes={maltreatmentTypes}
+          observedFeature={observedFeature}
+          year={year}
+          selectedGeographicFeature={selectedGeographicFeature}
+          data={data}
+        />
       </div>
       <div className="map-layout">
         <MainMap
@@ -25,6 +35,7 @@ function DisplayLayout({
           observedFeature={observedFeature}
           year={year}
           data={data}
+          setSelectedGeographicFeature={setSelectedGeographicFeature}
         />
       </div>
     </div>
@@ -37,6 +48,8 @@ DisplayLayout.propTypes = {
   maltreatmentTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
   observedFeature: PropTypes.string.isRequired,
   year: PropTypes.string.isRequired,
+  selectedGeographicFeature: PropTypes.string.isRequired,
+  setSelectedGeographicFeature: PropTypes.func.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   data: PropTypes.object.isRequired
 };

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -161,7 +161,7 @@ function MainMap({
               maltreatmentTypes
             ),
             color: 'red',
-            weight: 0.5,
+            weight: 2.0,
             stroke: true
           };
           newDataLayer.setFeatureStyle(

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -164,6 +164,11 @@ function MainMap({
             weight: 2.0,
             stroke: true
           };
+          if (mapType === 'maltreatment') {
+            // Simple zoom to point clicked and having fixed zoom level for counties
+            // See https://jira.tacc.utexas.edu/browse/COOKS-54
+            map.setView(e.latlng, 9);
+          }
           newDataLayer.setFeatureStyle(
             clickedGeographicFeature,
             highlightedStyle

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -161,7 +161,7 @@ function MainMap({
               observedFeature,
               maltreatmentTypes
             ),
-            color: 'red',
+            color: 'black',
             weight: 2.0,
             stroke: true
           };

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -51,7 +51,8 @@ function MainMap({
       minZoom: 6,
       maxZoom: 16,
       maxBounds: texasBounds,
-      maxBoundsViscosity: 1.0
+      maxBoundsViscosity: 1.0,
+      doubleClickZoom: false
     }).fitBounds(texasBounds);
 
     // Create Layers Control.

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -20,7 +20,8 @@ function MainMap({
   maltreatmentTypes,
   observedFeature,
   year,
-  data
+  data,
+  setSelectedGeographicFeature
 }) {
   const dataServer = window.location.origin;
 
@@ -30,14 +31,13 @@ function MainMap({
   const [dataLayer, setDataLayer] = useState(null);
   const [map, setMap] = useState(null);
   const [metaData, setMetaData] = useState(null);
-  const [selectedGeographicFeature, setSelectedGeographicFeature] = useState(
-    null
-  );
+  const [selectedGeoid, setSelectedGeoid] = useState(null);
 
-  const refSelectedGeographicFeature = useRef(selectedGeographicFeature); // Make a ref of the selected feature
+  const refSelectedGeoid = useRef(selectedGeoid); // Make a ref of the selected feature
 
   function updateSelectedGeographicFeature(newSelectedFeature) {
-    refSelectedGeographicFeature.current = newSelectedFeature;
+    refSelectedGeoid.current = newSelectedFeature;
+    setSelectedGeoid(newSelectedFeature);
     setSelectedGeographicFeature(newSelectedFeature);
   }
 
@@ -143,11 +143,11 @@ function MainMap({
         const clickedGeographicFeature =
           e.layer.properties[GEOID_KEY[geography]];
 
-        if (refSelectedGeographicFeature.current) {
-          newDataLayer.resetFeatureStyle(refSelectedGeographicFeature.current);
+        if (refSelectedGeoid.current) {
+          newDataLayer.resetFeatureStyle(refSelectedGeoid.current);
         }
 
-        if (clickedGeographicFeature !== refSelectedGeographicFeature.current) {
+        if (clickedGeographicFeature !== refSelectedGeoid.current) {
           updateSelectedGeographicFeature(clickedGeographicFeature);
           const highlightedStyle = {
             ...getFeatureStyle(
@@ -204,6 +204,7 @@ MainMap.propTypes = {
   maltreatmentTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
   observedFeature: PropTypes.string.isRequired,
   year: PropTypes.string.isRequired,
+  setSelectedGeographicFeature: PropTypes.func.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   data: PropTypes.object.isRequired
 };

--- a/client/src/components/ProTx/components/util.js
+++ b/client/src/components/ProTx/components/util.js
@@ -1,3 +1,5 @@
+import { getColor } from './maps/intervalColorScale';
+
 /**
  * Get meta data for observed features
  * @param {Object} data
@@ -145,4 +147,59 @@ export function getMaltreatmentAggregatedValue(
     });
   }
   return value;
+}
+
+/**
+ * Get style for feature
+ * @param {String} map type
+ * @param {Object} data
+ * @param {Object} metaData
+ * @param {String} geography
+ * @param {Number} year
+ * @param {Number} geoid
+ * @param {String} observedFeature
+ * @param Array<{String}> maltreatmentTypes
+ * @returns {Number} value (null if no value exists)
+ */
+export function getFeatureStyle(
+  mapType,
+  data,
+  metaData,
+  geography,
+  year,
+  geoid,
+  observedFeature,
+  maltreatmentTypes
+) {
+  let fillColor;
+  if (mapType === 'observedFeatures') {
+    const featureValue = getObservedFeatureValue(
+      data,
+      geography,
+      year,
+      geoid,
+      observedFeature
+    );
+    if (featureValue && metaData) {
+      fillColor = getColor(featureValue, metaData.min, metaData.max);
+    }
+  } else {
+    const featureValue = getMaltreatmentAggregatedValue(
+      data,
+      geography,
+      year,
+      geoid,
+      maltreatmentTypes
+    );
+    if (featureValue !== 0 && metaData) {
+      fillColor = getColor(featureValue, metaData.min, metaData.max);
+    }
+  }
+  return {
+    fillColor,
+    fill: fillColor,
+    stroke: false,
+    opacity: 1,
+    fillOpacity: 0.5
+  };
 }


### PR DESCRIPTION
## Overview: ##

Allows users to select geographic/map feature (e.g. a specific county) by clicking on it

## Related Jira tickets: ##

* [COOKS-34](https://jira.tacc.utexas.edu/browse/COOKS-34)

## Summary of Changes: ##
* Allow user to select a geographic feature (e.g. county)
* Disable leaflet maps default behavior of double-click zoom

## Testing Steps: ##
1. Click on a county while viewing maltreatment
2. Notice county has red outline and that county id is displayed above chart (just for illustrative purposes)
3. Click on the same county to deselect it or a different county to change selection

## UI Photos:

## Notes: ##
I added two follow on tickets:
* https://jira.tacc.utexas.edu/browse/COOKS-55
* https://jira.tacc.utexas.edu/browse/COOKS-54