### PR TITLE
Update MainMap.js to use black outline

### DIFF
--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -161,7 +161,7 @@ function MainMap({
               observedFeature,
               maltreatmentTypes
             ),
-            color: 'red',
+            color: 'black',
             weight: 2.0,
             stroke: true
           };


### PR DESCRIPTION
Line 164 - set the outline color to black.

## Overview: ##

## Related Jira tickets: ##

* [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)

## Summary of Changes: ##

## Testing Steps: ##
1.

## UI Photos:

## Notes: ##
