### PR TITLE
task/COOKS-63:  Allow selection of geographic features without a value

### DIFF
--- a/client/src/components/ProTx/components/util.js
+++ b/client/src/components/ProTx/components/util.js
@@ -186,6 +186,9 @@ export function getMaltreatmentSelectedValues(
 
 /**
  * Get style for feature
+ *
+ * If no value exists, then we return a transparent feature style if no value exists)
+ *
  * @param {String} map type
  * @param {Object} data
  * @param {Object} metaData
@@ -194,7 +197,7 @@ export function getMaltreatmentSelectedValues(
  * @param {Number} geoid
  * @param {String} observedFeature
  * @param Array<{String}> maltreatmentTypes
- * @returns {Number} value (null if no value exists)
+ * @returns {fillColor: string, fillOpacity: number, fill: boolean, stroke: boolean} style
  */
 export function getFeatureStyle(
   mapType,
@@ -230,11 +233,20 @@ export function getFeatureStyle(
       fillColor = getColor(featureValue, metaData.min, metaData.max);
     }
   }
+  if (fillColor) {
+    return {
+      fillColor,
+      fill: true,
+      stroke: false,
+      fillOpacity: 0.5
+    };
+  }
+  // if no color/data, we return a completely transparent style in order
+  // to allow for feature selection.
   return {
-    fillColor,
-    fill: fillColor,
+    fillColor: 'black',
+    fill: true,
     stroke: false,
-    opacity: 1,
-    fillOpacity: 0.5
+    fillOpacity: 0.0
   };
 }


### PR DESCRIPTION
## Overview: ##

Allows us to select geographic features (e.g. counties) even if they have no value.   Return transparent style if no value for feature so that we can then click on the feature to select it.

## Related Jira tickets: ##

* [COOKS-63](https://jira.tacc.utexas.edu/browse/COOKS-63)

## Testing Steps: ##
1. Click on counties without a value and confirm that they can be selected.
