### PR TITLE
RMSC Component CSS Styles Reset

### DIFF
--- a/client/src/components/ProTx/components/dashboard/MaltreatmentSelector.css
+++ b/client/src/components/ProTx/components/dashboard/MaltreatmentSelector.css
@@ -16,12 +16,12 @@
   border-bottom-right-radius: 6px;
 }
 .rmsc .dropdown-container .dropdown-content * {
-  color: #fff;
-  background: #111;
+  /* color: #fff; */
+  /* background: #111; */
 }
 .rmsc .dropdown-content .panel-content {
-  --rmsc-bgdd: var(--global-color-primary--dark) !important;
-  color: var(--global-color-accent--normal) !important;
+  /* --rmsc-bgdd: var(--global-color-primary--dark) !important; */
+  /* color: var(--global-color-accent--normal) !important; */
 }
 .dropdown-heading-value {
   color: var(--global-color-accent--normal);
@@ -32,11 +32,11 @@
 .item-renderer {
   font-style: normal;
   font-weight: normal;
-  color: var(--global-color-primary--dark) !important;
+  /* color: var(--global-color-primary--dark) !important; */
 }
 /* This will hide the weird highlighting in the component. */
-.rmsc .dropdown-content .panel-content .select-item,
+/* .rmsc .dropdown-content .panel-content .select-item,
 .rmsc .dropdown-content .panel-content .select-item .label,
 .rmsc .dropdown-content .panel-content *:hover {
   background-color: #111111 !important;
-}
+} */


### PR DESCRIPTION
This makes the rsmc dropdown component match the default styles the other dropdown menus are using in PPRD and PROD.

It retains the purple accent on teh dropdown header.

## Overview: ##

## Related Jira tickets: ##

* None

## Summary of Changes: ##

## Testing Steps: ##
1. Use Analysis Reports dropdown selector, make sure it is purple header text, white bg, black dropdown text

## UI Photos:

## Notes: ##
