### PR TITLE
Hotfix: Lock report to county and disable changing it

### DIFF
--- a/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
+++ b/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
@@ -82,17 +82,16 @@ function DashboardDisplay() {
         <Route path={`${protxRoute}/report`}>
           <DisplaySelectors
             mapType="observedFeatures"
-            geography={geography}
+            geography="county"
             maltreatmentTypes={maltreatmentTypes}
             observedFeature={observedFeature}
             year="2019"
-            setGeography={setGeography}
             setMaltreatmentTypes={setMaltreatmentTypes}
             setObservedFeature={setObservedFeature}
           />
           <ReportDisplayLayout
             mapType="observedFeatures"
-            geography={geography}
+            geography="county"
             maltreatmentTypes={maltreatmentTypes}
             observedFeature={observedFeature}
             year="2019"


### PR DESCRIPTION
## Overview: ##
Lock `report `to county and disable related dropdown

## Related Jira tickets: ##

None

## Summary of Changes: ##
* Lock `report `to county and disable related dropdown

