### PR TITLE
task/COOKS-66: keep geographic selection when switching options

### DIFF
--- a/client/src/components/ProTx/components/dashboard/AnalysisDisplayLayout.js
+++ b/client/src/components/ProTx/components/dashboard/AnalysisDisplayLayout.js
@@ -24,6 +24,7 @@ function AnalysisDisplayLayout({
           observedFeature={observedFeature}
           year={year}
           data={data}
+          selectedGeographicFeature={selectedGeographicFeature}
           setSelectedGeographicFeature={setSelectedGeographicFeature}
         />
       </div>

--- a/client/src/components/ProTx/components/dashboard/ReportDisplayLayout.js
+++ b/client/src/components/ProTx/components/dashboard/ReportDisplayLayout.js
@@ -24,6 +24,7 @@ function ReportDisplayLayout({
           observedFeature={observedFeature}
           year={year}
           data={data}
+          selectedGeographicFeature={selectedGeographicFeature}
           setSelectedGeographicFeature={setSelectedGeographicFeature}
         />
       </div>

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -190,7 +190,7 @@ function MainMap({
       setDataLayer(newDataLayer);
 
       // updated/new layer
-      if(selectedGeographicFeature) {
+      if (selectedGeographicFeature) {
         const highlightedStyle = {
           ...getFeatureStyle(
             mapType,

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -21,6 +21,7 @@ function MainMap({
   observedFeature,
   year,
   data,
+  selectedGeographicFeature,
   setSelectedGeographicFeature
 }) {
   const dataServer = window.location.origin;
@@ -137,14 +138,13 @@ function MainMap({
         maxNativeZoom: 14 // All tiles generated up to 14 zoom level
       });
 
-      // Handle
-
       if (dataLayer && layersControl) {
         // we will remove data layer from mapand from control
         layersControl.removeLayer(dataLayer);
         dataLayer.remove();
       }
 
+      // Add click handler
       newDataLayer.on('click', e => {
         const clickedGeographicFeature =
           e.layer.properties[GEOID_KEY[geography]];
@@ -188,6 +188,29 @@ function MainMap({
       newDataLayer.addTo(map);
       layersControl.addOverlay(newDataLayer, 'Data');
       setDataLayer(newDataLayer);
+
+      // updated/new layer
+      if(selectedGeographicFeature) {
+        const highlightedStyle = {
+          ...getFeatureStyle(
+            mapType,
+            data,
+            metaData,
+            geography,
+            year,
+            selectedGeographicFeature,
+            observedFeature,
+            maltreatmentTypes
+          ),
+          color: 'black',
+          weight: 2.0,
+          stroke: true
+        };
+        newDataLayer.setFeatureStyle(
+          selectedGeographicFeature,
+          highlightedStyle
+        );
+      }
     }
   }, [
     data,
@@ -210,6 +233,7 @@ MainMap.propTypes = {
   maltreatmentTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
   observedFeature: PropTypes.string.isRequired,
   year: PropTypes.string.isRequired,
+  selectedGeographicFeature: PropTypes.string.isRequired,
   setSelectedGeographicFeature: PropTypes.func.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   data: PropTypes.object.isRequired


### PR DESCRIPTION
## Overview: ##

Fixes issues where selected geographic feature lost its highlighting when options (year, type etc) were changed.

## Related Jira tickets: ##

* [COOKS-66](https://jira.tacc.utexas.edu/browse/COOKS-66)

## Summary of Changes: ##

* Preselect selected geographic feature when recreating layers

## Testing Steps: ##
1. Select area
2. Change settings (like maltreatment types)
3. Confirm area is still highlighted with black outline
