### PR TITLE
Change static color scale used on map to greater contrast

### DIFF
--- a/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
+++ b/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
@@ -21,7 +21,7 @@ function DashboardDisplay() {
   );
   const [year, setYear] = useState('2019');
   const [selectedGeographicFeature, setSelectedGeographicFeature] = useState(
-    ""
+    ''
   );
 
   const dispatch = useDispatch();

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -180,7 +180,7 @@ function MainMap({
             highlightedStyle
           );
         } else {
-          updateSelectedGeographicFeature("");
+          updateSelectedGeographicFeature('');
         }
       });
 

--- a/client/src/components/ProTx/components/maps/intervalColorScale.js
+++ b/client/src/components/ProTx/components/maps/intervalColorScale.js
@@ -1,24 +1,15 @@
 // eslint-disable-next-line no-unused-vars
-const coldToHotColors8 = [
-  `#ffffcc`,
-  `#ffeda0`,
-  `#fed976`,
-  `#feb24c`,
-  `#fd8d3c`,
-  `#fc4e2a`,
-  `#e31a1c`,
-  `#bd0026`,
-  `#800026`
+
+const colorbrewerClass6YlOrBr = [
+  '#ffffd4',
+  '#fee391',
+  '#fec44f',
+  '#fe9929',
+  '#d95f0e',
+  '#993404'
 ];
 
-const coldToHotColors6 = [
-  `#ffffb2`,
-  `#fed976`,
-  `#feb24c`,
-  `#fd8d3c`,
-  `#f03b20`,
-  `#bd0026`
-];
+const colorsArray = colorbrewerClass6YlOrBr;
 
 /** Interval color scale
 
@@ -30,8 +21,8 @@ const coldToHotColors6 = [
 export class IntervalColorScale {
   constructor(meta) {
     this.meta = meta;
-    this.colors = coldToHotColors6;
-    this.numberIntervals = coldToHotColors6.length;
+    this.colors = colorsArray;
+    this.numberIntervals = colorsArray.length;
   }
 
   getIntervalValues() {
@@ -50,5 +41,5 @@ export class IntervalColorScale {
 // TODO moved into IntervalColorScale
 export function getColor(value, min, max) {
   const binValue = Math.min(Math.floor(6 * ((value - min) / (max - min))), 5);
-  return coldToHotColors6[binValue];
+  return colorsArray[binValue];
 }


### PR DESCRIPTION
Swaps out the colors array used in the MainMap component. 

Also fixes two tiny linting errors where double quotes were used instead of single quotes in MainMap and DashboardDisplay.

## Overview: ##

## Related Jira tickets: ##

* [COOKS-76](https://jira.tacc.utexas.edu/browse/COOKS-76)

## Summary of Changes: ##

## Testing Steps: ##
1. Run project and check map colors.

## UI Photos:

Old colors:
<img width="1165" alt="Screen Shot 2021-07-08 at 7 09 48 PM" src="https://user-images.githubusercontent.com/3238078/125004946-32c0bf00-e020-11eb-98ef-fe2fc0a15df6.png">

New colors:
<img width="1161" alt="Screen Shot 2021-07-08 at 7 10 10 PM" src="https://user-images.githubusercontent.com/3238078/125004971-39e7cd00-e020-11eb-8f90-a20aa6893c97.png">


## Notes: ##
