### PR TITLE
COOKS-78 & COOKS-80 - ReportsChart Layout Tweaks

### DIFF
--- a/client/src/components/ProTx/components/charts/PredictiveFeaturesTable.css
+++ b/client/src/components/ProTx/components/charts/PredictiveFeaturesTable.css
@@ -1,31 +1,52 @@
 .feature-table * {
   font-family: 'Roboto Condensed', sans-serif;
-}
-.feature-table * {
   font-size: 0.8rem;
 }
 sup {
   font-style: italic;
   font-weight: 700;
+  color: rgb(100, 255, 150);
 }
-.feature-table-chart {
-  margin: 1vh 1vw;
+.feature-table-chart,
+.feature-table-chart-selection {
   font-weight: 600;
 }
+.feature-table-chart {
+  margin: 1vh 1vw 3.7vh;
+}
+.feature-table-chart-selection {
+  margin: 1vh 1vw;
+}
 .feature-table-chart tr th,
-.feature-table-chart tr td {
+.feature-table-chart tr td,
+.feature-table-chart-selection tr th,
+.feature-table-chart-selection tr td {
   border-bottom: 1px solid #000000;
   padding: 0.5vh 0.2vw;
   text-align: center;
 }
+.feature-table-chart-selection tr:nth-child(odd),
 .feature-table-chart tr:nth-child(odd) {
   background-color: #efefef;
 }
+.feature-table-chart-selection tr th,
 .feature-table-chart tr th {
+  font-size: 0.9rem;
   line-height: 2vh;
   background-color: #222222;
   color: #ffffff;
 }
+.feature-table-chart-selection tr th.ensemble-rank-label,
+.feature-table-chart tr th.ensemble-rank-label {
+  color: rgb(222, 166, 255) !important;
+}
+.feature-table-chart-selection tr td.ensemble-rank-value,
+.feature-table-chart tr td.ensemble-rank-value {
+  background-color: rgba(222, 166, 255, 0.2);
+  border-left: 1px solid #000;
+  border-right: 1px solid #000;
+}
+.feature-table-chart-selection tr td:first-child,
 .feature-table-chart tr td:first-child {
   padding-left: 2vw;
   text-align: left;
@@ -36,12 +57,37 @@ sup {
 .feature-table-chart-cell {
   width: 12%;
 }
+.feature-table-selected-feature td {
+  background-color: rgb(20, 50, 80);
+  color: rgb(80, 220, 255);
+}
+.feature-table-selected-feature td.ensemble-rank-value {
+  background-color: rgb(80, 50, 100) !important;
+  color: rgb(255, 180, 0);
+}
 .feature-table-info * {
   font-weight: 400;
 }
 .feature-table-info,
-.feature-table-description,
-.feature-table-information,
-.feature-table-annotation {
+.feature-table-information {
   margin: 1vh 1vw;
+}
+.feature-table-info {
+  margin-top: 1vh;
+  border: 1px solid #000000;
+  border-left: 3px solid #000000;
+  border-right: 3px solid #000000;
+}
+.feature-table-annotation {
+  margin: 0;
+  padding: 0.5vh 0.5vw;
+  background-color: rgba(100, 200, 150, 0.1);
+}
+.feature-table-annotation-prefix,
+.feature-table-annotation-text {
+  margin-right: 0.2vw;
+}
+.feature-table-annotation-prefix {
+  font-weight: 600;
+  font-style: italic;
 }

--- a/client/src/components/ProTx/components/charts/PredictiveFeaturesTable.css
+++ b/client/src/components/ProTx/components/charts/PredictiveFeaturesTable.css
@@ -5,7 +5,7 @@
 sup {
   font-style: italic;
   font-weight: 700;
-  color: rgb(100, 255, 150);
+  color: rgb(80, 220, 255);
 }
 .feature-table-chart,
 .feature-table-chart-selection {
@@ -59,7 +59,7 @@ sup {
 }
 .feature-table-selected-feature td {
   background-color: rgb(20, 50, 80);
-  color: rgb(80, 220, 255);
+  color: rgb(255, 255, 255);
 }
 .feature-table-selected-feature td.ensemble-rank-value {
   background-color: rgb(80, 50, 100) !important;
@@ -77,11 +77,12 @@ sup {
   border: 1px solid #000000;
   border-left: 3px solid #000000;
   border-right: 3px solid #000000;
+  mix-blend-mode: multiply;
 }
 .feature-table-annotation {
   margin: 0;
   padding: 0.5vh 0.5vw;
-  background-color: rgba(100, 200, 150, 0.1);
+  background-color: rgba(80, 220, 255, 0.2);
 }
 .feature-table-annotation-prefix,
 .feature-table-annotation-text {

--- a/client/src/components/ProTx/components/charts/PredictiveFeaturesTable.css
+++ b/client/src/components/ProTx/components/charts/PredictiveFeaturesTable.css
@@ -75,14 +75,10 @@ sup {
 .feature-table-info {
   margin-top: 1vh;
   border: 1px solid #000000;
-  border-left: 3px solid #000000;
-  border-right: 3px solid #000000;
-  mix-blend-mode: multiply;
 }
 .feature-table-annotation {
   margin: 0;
   padding: 0.5vh 0.5vw;
-  background-color: rgba(80, 220, 255, 0.2);
 }
 .feature-table-annotation-prefix,
 .feature-table-annotation-text {

--- a/client/src/components/ProTx/components/charts/PredictiveFeaturesTable.js
+++ b/client/src/components/ProTx/components/charts/PredictiveFeaturesTable.js
@@ -1,94 +1,125 @@
 import React from 'react';
+import {
+  PREDICTIVE_FEATURES_TABLE_DATA,
+  PREDICTIVE_FEATURES_TABLE_NOTES
+} from './predictiveFeaturesTableData';
 import './PredictiveFeaturesTable.css';
 
-function PredictiveFeaturesTable() {
+const tableData = PREDICTIVE_FEATURES_TABLE_DATA;
+const tableNotes = PREDICTIVE_FEATURES_TABLE_NOTES;
+
+/**
+ * TODO: Pass in the selectedFeature object with its associated data.
+ * TODO: Use object for conditional rendering in the table.
+ */
+
+const selectedFeatureCheck = false;
+const selectedFeature = {
+  Demographic_Feature: 'SF_NAME',
+  Rank_By_Causal_Strength: 'SF_RBCS',
+  Rank_By_Random_Forest_Feature_Importance: 'SF_RBRFFI',
+  Average_Rank: 'SF_AR',
+  Ensemble_Rank: 'SF_ER'
+};
+
+const featuresTableHeaderRow = () => {
+  return (
+    <tr>
+      <th className="feature-table-chart-label">Demographic Feature</th>
+      <th className="feature-table-chart-cell ensemble-rank-label">
+        Ensemble Rank
+      </th>
+      <th className="feature-table-chart-cell">
+        Rank by Causal Strength <sup>a</sup>
+      </th>
+      <th className="feature-table-chart-cell">
+        Rank by Random Forest Feature Importance <sup>b</sup>
+      </th>
+      <th className="feature-table-chart-cell">Average Rank</th>
+    </tr>
+  );
+};
+
+const featureTableHeader = featuresTableHeaderRow();
+
+const featureTableData = tableData.map((data, index) => {
+  const i = index;
+  return (
+    <tr key={i}>
+      <td>{data.Demographic_Feature}</td>
+      <td className="ensemble-rank-value">{data.Ensemble_Rank}</td>
+      <td>{data.Rank_By_Causal_Strength}</td>
+      <td>{data.Rank_By_Random_Forest_Feature_Importance}</td>
+      <td>{data.Average_Rank}</td>
+    </tr>
+  );
+});
+
+const featureTableAnnotations = tableNotes.map((noteRow, index) => {
+  const i = index;
+  return (
+    <div className="feature-table-annotation" key={i}>
+      <span className="feature-table-annotation-prefix">
+        {noteRow.Note_Prefix}
+      </span>
+      <span className="feature-table-annotation-text">{noteRow.Note_Text}</span>
+    </div>
+  );
+});
+
+const getFeatureTable = () => {
+  if (selectedFeatureCheck) {
+    const getSelectedFeatureTableData = feature => {
+      const currentSelectedFeature = feature;
+      return (
+        <tr className="feature-table-selected-feature">
+          <td>{currentSelectedFeature.Demographic_Feature}</td>
+          <td className="ensemble-rank-value">
+            {currentSelectedFeature.Ensemble_Rank}
+          </td>
+          <td>{currentSelectedFeature.Rank_By_Causal_Strength}</td>
+          <td>
+            {currentSelectedFeature.Rank_By_Random_Forest_Feature_Importance}
+          </td>
+          <td>{currentSelectedFeature.Average_Rank}</td>
+        </tr>
+      );
+    };
+
+    const selectedFeatureTableData = getSelectedFeatureTableData(
+      selectedFeature
+    );
+
+    return (
+      <div className="feature-table">
+        <div className="feature-table-chart-selection">
+          <table>
+            {featureTableHeader}
+            {featureTableData}
+            {selectedFeatureTableData}
+          </table>
+        </div>
+        <div className="feature-table-info">{featureTableAnnotations}</div>
+      </div>
+    );
+  }
   return (
     <div className="feature-table">
       <div className="feature-table-chart">
         <table>
-          <tr>
-            <th className="feature-table-chart-label">Demographic Feature</th>
-            <th className="feature-table-chart-cell">
-              Rank by Causal Strength <sup>a</sup>
-            </th>
-            <th className="feature-table-chart-cell">
-              Rank by Random Forest Feature Importance <sup>b</sup>
-            </th>
-            <th className="feature-table-chart-cell">Average Rank</th>
-            <th className="feature-table-chart-cell">Ensemble Rank</th>
-          </tr>
-          <tr>
-            <td>Number of Single Parents</td>
-            <td>1</td>
-            <td>1</td>
-            <td>1</td>
-            <td>1</td>
-          </tr>
-          <tr>
-            <td>Number of Persons in Poverty</td>
-            <td>4</td>
-            <td>2</td>
-            <td>3</td>
-            <td>2</td>
-          </tr>
-          <tr>
-            <td>Per Capita Income</td>
-            <td>3</td>
-            <td>5</td>
-            <td>4</td>
-            <td>3</td>
-          </tr>
-          <tr>
-            <td>Number of Persons Age 17 and Younger</td>
-            <td>6</td>
-            <td>4</td>
-            <td>5</td>
-            <td>4</td>
-          </tr>
-          <tr>
-            <td>Number of Persons without High School Diploma</td>
-            <td>12</td>
-            <td>3</td>
-            <td>7.5</td>
-            <td>5</td>
-          </tr>
-          <tr>
-            <td>Number of Persons Living in Group Quarters</td>
-            <td>2</td>
-            <td>18</td>
-            <td>10</td>
-            <td>6</td>
-          </tr>
-          <tr>
-            <td>Number of Households with Crowding</td>
-            <td>5</td>
-            <td>16</td>
-            <td>10.5</td>
-            <td>7</td>
-          </tr>
+          {featureTableHeader}
+          {featureTableData}
         </table>
       </div>
-
-      <div className="feature-table-info">
-        <div className="feature-table-description">
-          Table 1. Top seven features related to child maltreatment based on
-          county-level total maltreatment counts for the state of Texas,
-          2011-2019. Analysis was perfomed with two different models; features
-          are ranked according to their influences in each model type. The top
-          five features and rankings are shown for each model; features ranked
-          in the top five for both models are highlighted in yellow.
-        </div>
-        <div className="feature-table-annotation">
-          <sup>a</sup> Ranking by absolute value of estimated causal strength
-          where 1 indicates the largest causal impact.
-        </div>
-        <div className="feature-table-annotation">
-          <sup>b</sup> Ranking by random forest feature importance where 1
-          indicates the most important feature.
-        </div>
-      </div>
+      <div className="feature-table-info">{featureTableAnnotations}</div>
     </div>
   );
+};
+
+const featureTable = getFeatureTable();
+
+function PredictiveFeaturesTable() {
+  return featureTable;
 }
 
 export default PredictiveFeaturesTable;

--- a/client/src/components/ProTx/components/charts/ReportChart.js
+++ b/client/src/components/ProTx/components/charts/ReportChart.js
@@ -1,9 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import PredictiveFeaturesTable from './PredictiveFeaturesTable';
-import PredictiveFeaturesPlot from './PredictiveFeaturesPlot';
-import ChartInstructions from './ChartInstructions';
+// import PredictiveFeaturesPlot from './PredictiveFeaturesPlot';
+// import ChartInstructions from './ChartInstructions';
 import './ReportChart.css';
+
+/**
+ * TODO: Complete the PredictiveFeaturesPlot.
+ * TODO: Uncomment the disabled code.
+ */
 
 function ReportChart({
   mapType,
@@ -14,20 +19,21 @@ function ReportChart({
   selectedGeographicFeature,
   data
 }) {
-  const reportDropdownInstructions = [
-    'Map is restricted to Demographic Features.',
-    'Map is restricted to the County Area.',
-    'Select a Demographic Feature.',
-    'TimeFrame is restricted to most recent census data (2019).'
-  ];
-  const reportMapInstructions = ['Select a Geographic Region.'];
-  const reportShowDescription = false;
-  const reportDescription = 'Description needed.';
+  // const reportDropdownInstructions = [
+  //   'Map is restricted to Demographic Features.',
+  //   'Map is restricted to the County Area.',
+  //   'Select a Demographic Feature.',
+  //   'TimeFrame is restricted to most recent census data (2019).'
+  // ];
+  // const reportMapInstructions = ['Select a Geographic Region.'];
+  // const reportShowDescription = false;
+  // const reportDescription = 'Description needed.';
 
   if (selectedGeographicFeature) {
     return (
       <div className="report-chart">
-        <PredictiveFeaturesPlot
+        <PredictiveFeaturesTable />
+        {/* <PredictiveFeaturesPlot
           mapType={mapType}
           geography={geography}
           maltreatmentTypes={maltreatmentTypes}
@@ -35,20 +41,19 @@ function ReportChart({
           year={year}
           selectedGeographicFeature={selectedGeographicFeature}
           data={data}
-        />
+        /> */}
       </div>
     );
   }
   return (
     <div className="report-chart">
       <PredictiveFeaturesTable />
-      <hr />
-      <ChartInstructions
+      {/* <ChartInstructions
         dropdownInstructions={reportDropdownInstructions}
         mapInstructions={reportMapInstructions}
         showDescription={reportShowDescription}
         description={reportDescription}
-      />
+      /> */}
     </div>
   );
 }

--- a/client/src/components/ProTx/components/charts/predictiveFeaturesTableData.js
+++ b/client/src/components/ProTx/components/charts/predictiveFeaturesTableData.js
@@ -1,48 +1,48 @@
 export const PREDICTIVE_FEATURES_TABLE_DATA = [
   {
-    Demographic_Feature: 'number of single parents',
+    Demographic_Feature: 'Number of Single Parents',
     Rank_By_Causal_Strength: '1',
     Rank_By_Random_Forest_Feature_Importance: '1',
     Average_Rank: '1.0',
     Ensemble_Rank: '1'
   },
   {
-    Demographic_Feature: 'number of persons in poverty',
+    Demographic_Feature: 'Number of Persons in Poverty',
     Rank_By_Causal_Strength: '4',
     Rank_By_Random_Forest_Feature_Importance: '2',
     Average_Rank: '3.0',
     Ensemble_Rank: '2'
   },
   {
-    Demographic_Feature: 'per capita income',
+    Demographic_Feature: 'Per Capita Income',
     Rank_By_Causal_Strength: '3',
     Rank_By_Random_Forest_Feature_Importance: '5',
     Average_Rank: '4.0',
     Ensemble_Rank: '3'
   },
   {
-    Demographic_Feature: 'number of persons age 17 and younger',
+    Demographic_Feature: 'Number of Persons Age 17 and Younger',
     Rank_By_Causal_Strength: '6',
     Rank_By_Random_Forest_Feature_Importance: '4',
     Average_Rank: '5.0',
     Ensemble_Rank: '4'
   },
   {
-    Demographic_Feature: 'number of persons without high school diploma',
+    Demographic_Feature: 'Number of Persons without High School Diploma',
     Rank_By_Causal_Strength: '12',
     Rank_By_Random_Forest_Feature_Importance: '3',
     Average_Rank: '7.5',
     Ensemble_Rank: '5'
   },
   {
-    Demographic_Feature: 'number of persons living in group quarters',
+    Demographic_Feature: 'Number of Persons Living in Group Quarters',
     Rank_By_Causal_Strength: '2',
     Rank_By_Random_Forest_Feature_Importance: '18',
     Average_Rank: '10.0',
     Ensemble_Rank: '6'
   },
   {
-    Demographic_Feature: 'number of households with crowding',
+    Demographic_Feature: 'Number of Households with Crowding',
     Rank_By_Causal_Strength: '5',
     Rank_By_Random_Forest_Feature_Importance: '16',
     Average_Rank: '10.5',

--- a/client/src/components/ProTx/components/charts/predictiveFeaturesTableData.js
+++ b/client/src/components/ProTx/components/charts/predictiveFeaturesTableData.js
@@ -1,0 +1,69 @@
+export const PREDICTIVE_FEATURES_TABLE_DATA = [
+  {
+    Demographic_Feature: 'number of single parents',
+    Rank_By_Causal_Strength: '1',
+    Rank_By_Random_Forest_Feature_Importance: '1',
+    Average_Rank: '1.0',
+    Ensemble_Rank: '1'
+  },
+  {
+    Demographic_Feature: 'number of persons in poverty',
+    Rank_By_Causal_Strength: '4',
+    Rank_By_Random_Forest_Feature_Importance: '2',
+    Average_Rank: '3.0',
+    Ensemble_Rank: '2'
+  },
+  {
+    Demographic_Feature: 'per capita income',
+    Rank_By_Causal_Strength: '3',
+    Rank_By_Random_Forest_Feature_Importance: '5',
+    Average_Rank: '4.0',
+    Ensemble_Rank: '3'
+  },
+  {
+    Demographic_Feature: 'number of persons age 17 and younger',
+    Rank_By_Causal_Strength: '6',
+    Rank_By_Random_Forest_Feature_Importance: '4',
+    Average_Rank: '5.0',
+    Ensemble_Rank: '4'
+  },
+  {
+    Demographic_Feature: 'number of persons without high school diploma',
+    Rank_By_Causal_Strength: '12',
+    Rank_By_Random_Forest_Feature_Importance: '3',
+    Average_Rank: '7.5',
+    Ensemble_Rank: '5'
+  },
+  {
+    Demographic_Feature: 'number of persons living in group quarters',
+    Rank_By_Causal_Strength: '2',
+    Rank_By_Random_Forest_Feature_Importance: '18',
+    Average_Rank: '10.0',
+    Ensemble_Rank: '6'
+  },
+  {
+    Demographic_Feature: 'number of households with crowding',
+    Rank_By_Causal_Strength: '5',
+    Rank_By_Random_Forest_Feature_Importance: '16',
+    Average_Rank: '10.5',
+    Ensemble_Rank: '7'
+  }
+];
+
+export const PREDICTIVE_FEATURES_TABLE_NOTES = [
+  {
+    Note_Prefix: 'Table 1.',
+    Note_Text:
+      'Top five features related to child maltreatment based on county-level total maltreatment counts for the state of Texas, 2011-2019. Analysis was performed with two different models; features are ranked according to their influence in each model type. The top five features and rankings are shown for each model; features ranked in the top five for both models are highlighted in yellow.'
+  },
+  {
+    Note_Prefix: '\u1d43',
+    Note_Text:
+      'Ranking by absolute value of estimated causal strength where 1 indicates the largest causal impact'
+  },
+  {
+    Note_Prefix: '\u1d47',
+    Note_Text:
+      'Ranking by random forest feature importance where 1 indicates the most important feature'
+  }
+];


### PR DESCRIPTION
Completed redesigning the ReportChart and the PredictiveFeaturesTable. Table now uses data instead of hard coded values. Content is in place to handle feature selection display when chart plot is completed. ReportCHart is currently commenting out Plots and Instructions until Plot is completed. This addresses tasks COOKS-78 and COOKS-80.

## Overview: ##

## Related Jira tickets: ##

* [COOKS-78](https://jira.tacc.utexas.edu/browse/COOKS-78)
* [COOKS-80](https://jira.tacc.utexas.edu/browse/COOKS-80)

## Summary of Changes: ##

## Testing Steps: ##

1. Build and run the project. Use the PredictiveFeatures map under Analysis Reports.

## UI Photos:

When no selection is passed into the plot (the only state for the current time being).

<img width="1672" alt="Screen Shot 2021-07-09 at 8 05 10 PM" src="https://user-images.githubusercontent.com/3238078/125147448-0032c700-e0f1-11eb-91e5-ac5762946188.png">

When the current selectedFeature value is passed into the chart. This is not enabled yet, need to develop a method to generate the selectedFeature data object the chart expects.

<img width="1670" alt="Screen Shot 2021-07-09 at 8 06 49 PM" src="https://user-images.githubusercontent.com/3238078/125147480-38d2a080-e0f1-11eb-9188-c4ea251d81c2.png">

## Notes: ##
