### PR TITLE
Maltreatment chart verbiage refinement.

### DIFF
--- a/client/src/components/ProTx/components/charts/MaltreatmentTypesPlot.css
+++ b/client/src/components/ProTx/components/charts/MaltreatmentTypesPlot.css
@@ -81,11 +81,6 @@
   font-weight: normal;
   content: ', ';
 }
-.maltreatment-types-plot-chart-summary,
-.maltreatment-types-plot-selected-type-summary:last-child:not(:only-child):before {
-  font-weight: normal;
-  content: ' and ';
-}
 .maltreatment-types-plot-selected-type:last-child:not(:only-child):after,
 .maltreatment-types-plot-selected-type-summary:last-child:not(:only-child):after {
   font-weight: normal;

--- a/client/src/components/ProTx/components/charts/MaltreatmentTypesPlot.js
+++ b/client/src/components/ProTx/components/charts/MaltreatmentTypesPlot.js
@@ -250,7 +250,7 @@ function MaltreatmentTypesPlot({
           <span className="maltreatment-types-plot-chart-summary">
             This chart was generated using {yearMaltreatment}{' '}
             {mapTypeMaltreatment} data for {geographyMaltreatment}{' '}
-            {selectedGeographicFeatureMaltreatment} using the data type(s)
+            {selectedGeographicFeatureMaltreatment} using these data type(s):
           </span>
           {maltreatmentTypesListMaltreatment.map(type => (
             <span


### PR DESCRIPTION
Fix for unwanted `and` stuck before single value lists of selected features.

## Overview: ##

Tweaks the syntax fo the chart description to be universally correct.

## Related Jira tickets: ##

* No ticket.

## Summary of Changes: ##

## Testing Steps: ##
1. Run project and generate Maltreatment chart. Verify text.

## UI Photos:

<img width="821" alt="Screen Shot 2021-07-26 at 6 48 51 PM" src="https://user-images.githubusercontent.com/3238078/127073379-c99633a5-935c-43ad-8d5c-27046e2959f3.png">

## Notes: ##
