### PR TITLE
Task/cooks 68

### DIFF
--- a/client/src/components/ProTx/components/charts/AnalysisChart.js
+++ b/client/src/components/ProTx/components/charts/AnalysisChart.js
@@ -46,6 +46,7 @@ function AnalysisChart({
             year={year}
             selectedGeographicFeature={selectedGeographicFeature}
             data={data}
+            // debugState
           />
         </div>
       );
@@ -74,6 +75,7 @@ function AnalysisChart({
             year={year}
             selectedGeographicFeature={selectedGeographicFeature}
             data={data}
+            // debugState
           />
         </div>
       );

--- a/client/src/components/ProTx/components/charts/MaltreatmentTypesPlot.js
+++ b/client/src/components/ProTx/components/charts/MaltreatmentTypesPlot.js
@@ -12,17 +12,13 @@ import './MaltreatmentTypesPlot.css';
 /**
  * TODOS FOR ALL PLOT COMPONENTS.
  *
- * TODO: Refactor debug state to be a property of the component.
- *   - Default to false, pass in with component usage in parent.
  * TODO: Refactor colorScales assignment out into utils.
  *   - Will be used by other components.
  * TODO: Investigate moving plot configuration generation code into  utils.
  *   - Used across multiple components, refactor into library.
  */
 
-// Set this to true to inspect the component data in a tabular view.
-// const debugState = false;
-const debugState = true;
+// Passing the debugState property will render component data in debug mode.
 
 function MaltreatmentTypesPlot({
   mapType,
@@ -30,7 +26,8 @@ function MaltreatmentTypesPlot({
   maltreatmentTypes,
   year,
   selectedGeographicFeature,
-  data
+  data,
+  debugState
 }) {
   // Define Data Marshalling Methods.
 
@@ -62,7 +59,6 @@ function MaltreatmentTypesPlot({
   };
 
   // Variable Assignment Using Data Marshalling Methods.
-
   const maltreatmentMeta = MALTREATMENT;
   const geoid = selectedGeographicFeature;
 
@@ -306,7 +302,8 @@ MaltreatmentTypesPlot.propTypes = {
   year: PropTypes.string.isRequired,
   selectedGeographicFeature: PropTypes.string.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
-  data: PropTypes.object.isRequired
+  data: PropTypes.object.isRequired,
+  debugState: PropTypes.bool.isRequired
 };
 
 export default MaltreatmentTypesPlot;

--- a/client/src/components/ProTx/components/charts/MaltreatmentTypesPlot.js
+++ b/client/src/components/ProTx/components/charts/MaltreatmentTypesPlot.js
@@ -21,7 +21,8 @@ import './MaltreatmentTypesPlot.css';
  */
 
 // Set this to true to inspect the component data in a tabular view.
-const debugState = false;
+// const debugState = false;
+const debugState = true;
 
 function MaltreatmentTypesPlot({
   mapType,

--- a/client/src/components/ProTx/components/charts/ObservedFeaturesPlot.js
+++ b/client/src/components/ProTx/components/charts/ObservedFeaturesPlot.js
@@ -5,9 +5,16 @@ import DebugPlot from './DebugPlot';
 import { OBSERVED_FEATURES } from '../meta';
 import './ObservedFeaturesPlot.css';
 
-// Set this to true to inspect the component data in a tabular view.
-// const debugState = false;
-const debugState = true;
+/**
+ * TODOS FOR ALL PLOT COMPONENTS.
+ *
+ * TODO: Refactor colorScales assignment out into utils.
+ *   - Will be used by other components.
+ * TODO: Investigate moving plot configuration generation code into  utils.
+ *   - Used across multiple components, refactor into library.
+ */
+
+// Passing the debugState property will render component data in debug mode.
 
 function ObservedFeaturesPlot({
   mapType,
@@ -16,7 +23,8 @@ function ObservedFeaturesPlot({
   observedFeature,
   year,
   selectedGeographicFeature,
-  data
+  data,
+  debugState
 }) {
   // Define Data Marshalling Methods.
 
@@ -218,7 +226,8 @@ ObservedFeaturesPlot.propTypes = {
   year: PropTypes.string.isRequired,
   selectedGeographicFeature: PropTypes.string.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
-  data: PropTypes.object.isRequired
+  data: PropTypes.object.isRequired,
+  debugState: PropTypes.bool.isRequired
 };
 
 export default ObservedFeaturesPlot;

--- a/client/src/components/ProTx/components/charts/ObservedFeaturesPlot.js
+++ b/client/src/components/ProTx/components/charts/ObservedFeaturesPlot.js
@@ -6,7 +6,8 @@ import { OBSERVED_FEATURES } from '../meta';
 import './ObservedFeaturesPlot.css';
 
 // Set this to true to inspect the component data in a tabular view.
-const debugState = false;
+// const debugState = false;
+const debugState = true;
 
 function ObservedFeaturesPlot({
   mapType,

--- a/client/src/components/ProTx/components/charts/PredictiveFeaturesPlot.js
+++ b/client/src/components/ProTx/components/charts/PredictiveFeaturesPlot.js
@@ -4,9 +4,16 @@ import Plot from 'react-plotly.js';
 import DebugPlot from './DebugPlot';
 import './PredictiveFeaturesPlot.css';
 
-// Set this to true to inspect the component data in a tabular view.
-// const debugState = false;
-const debugState = true;
+/**
+ * TODOS FOR ALL PLOT COMPONENTS.
+ *
+ * TODO: Refactor colorScales assignment out into utils.
+ *   - Will be used by other components.
+ * TODO: Investigate moving plot configuration generation code into  utils.
+ *   - Used across multiple components, refactor into library.
+ */
+
+// Passing the debugState property will render component data in debug mode.
 
 function PredictiveFeaturesPlot({
   mapType,
@@ -15,7 +22,8 @@ function PredictiveFeaturesPlot({
   observedFeature,
   year,
   selectedGeographicFeature,
-  data
+  data,
+  debugState
 }) {
   // Define Data Marshalling Methods.
 
@@ -209,7 +217,8 @@ PredictiveFeaturesPlot.propTypes = {
   year: PropTypes.string.isRequired,
   selectedGeographicFeature: PropTypes.string.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
-  data: PropTypes.object.isRequired
+  data: PropTypes.object.isRequired,
+  debugState: PropTypes.bool.isRequired
 };
 
 export default PredictiveFeaturesPlot;

--- a/client/src/components/ProTx/components/charts/PredictiveFeaturesPlot.js
+++ b/client/src/components/ProTx/components/charts/PredictiveFeaturesPlot.js
@@ -5,7 +5,8 @@ import DebugPlot from './DebugPlot';
 import './PredictiveFeaturesPlot.css';
 
 // Set this to true to inspect the component data in a tabular view.
-const debugState = false;
+// const debugState = false;
+const debugState = true;
 
 function PredictiveFeaturesPlot({
   mapType,

--- a/client/src/components/ProTx/components/charts/ReportChart.js
+++ b/client/src/components/ProTx/components/charts/ReportChart.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import PredictiveFeaturesTable from './PredictiveFeaturesTable';
-// import PredictiveFeaturesPlot from './PredictiveFeaturesPlot';
-// import ChartInstructions from './ChartInstructions';
+import PredictiveFeaturesPlot from './PredictiveFeaturesPlot';
+import ChartInstructions from './ChartInstructions';
 import './ReportChart.css';
 
 /**
@@ -19,21 +19,21 @@ function ReportChart({
   selectedGeographicFeature,
   data
 }) {
-  // const reportDropdownInstructions = [
-  //   'Map is restricted to Demographic Features.',
-  //   'Map is restricted to the County Area.',
-  //   'Select a Demographic Feature.',
-  //   'TimeFrame is restricted to most recent census data (2019).'
-  // ];
-  // const reportMapInstructions = ['Select a Geographic Region.'];
-  // const reportShowDescription = false;
-  // const reportDescription = 'Description needed.';
+  const reportDropdownInstructions = [
+    'Map is restricted to Demographic Features.',
+    'Map is restricted to the County Area.',
+    'Select a Demographic Feature.',
+    'TimeFrame is restricted to most recent census data (2019).'
+  ];
+  const reportMapInstructions = ['Select a Geographic Region.'];
+  const reportShowDescription = false;
+  const reportDescription = 'Description needed.';
 
   if (selectedGeographicFeature) {
     return (
       <div className="report-chart">
         <PredictiveFeaturesTable />
-        {/* <PredictiveFeaturesPlot
+        <PredictiveFeaturesPlot
           mapType={mapType}
           geography={geography}
           maltreatmentTypes={maltreatmentTypes}
@@ -41,19 +41,19 @@ function ReportChart({
           year={year}
           selectedGeographicFeature={selectedGeographicFeature}
           data={data}
-        /> */}
+        />
       </div>
     );
   }
   return (
     <div className="report-chart">
       <PredictiveFeaturesTable />
-      {/* <ChartInstructions
+      <ChartInstructions
         dropdownInstructions={reportDropdownInstructions}
         mapInstructions={reportMapInstructions}
         showDescription={reportShowDescription}
         description={reportDescription}
-      /> */}
+      />
     </div>
   );
 }

--- a/client/src/components/ProTx/components/charts/ReportChart.js
+++ b/client/src/components/ProTx/components/charts/ReportChart.js
@@ -41,6 +41,7 @@ function ReportChart({
           year={year}
           selectedGeographicFeature={selectedGeographicFeature}
           data={data}
+          // debugState
         />
       </div>
     );


### PR DESCRIPTION
## Overview: ##

## Related Jira tickets: ##

* [COOKS-68](https://jira.tacc.utexas.edu/browse/COOKS-68)

## Summary of Changes: ##

Added an optional boolen propType named `debugState` that replaces the internal plot configuration value for displaying debug data about the component. Now, rather than edit the component configuration, you can simply pass in the debugState prop. If no prop is provided, the component defaults to false and shows the normal plot content.

## Testing Steps: ##

1. Add the `debugState` property to any of the existing plot components (MaltreatmentTypesPlot, ObservedFeaturesPlot and PredictiveFeaturesPlot) where they are declared in the `AnalysisChart` or `ReportChart` components.  

```
 #  Example: AnalysisChart. - line 38.

  if (mapType === 'maltreatment') {
    if (selectedGeographicFeature && maltreatmentTypes.length !== 0) {
      return (
        <div className="analysis-chart">
          <MaltreatmentTypesPlot
            mapType={mapType}
            geography={geography}
            maltreatmentTypes={maltreatmentTypes}
            year={year}
            selectedGeographicFeature={selectedGeographicFeature}
            data={data}
            debugState     // Optional propType added.
          />
        </div>
      );
    }
```

## UI Photos:

<img width="1410" alt="Screen Shot 2021-08-02 at 6 19 16 PM" src="https://user-images.githubusercontent.com/3238078/127935184-3cd32de1-473d-4432-ae0c-99d3e63e88fb.png">


## Notes: ##

All current plots will have the new debugState propTypes added but commented out in the current component declarations after this merge.