### PR TITLE
Task/cooks 50 add percent toggle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,15 +43,6 @@ jobs:
         cp portal/apps/workbench/templates/portal/apps/workbench/index.j2 portal/apps/workbench/templates/portal/apps/workbench/index.html
         poetry run pytest --cov-config=.coveragerc --cov=portal --cov-report=xml -ra
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./server/coverage.xml
-        flags: unittests
-        name: cep-server-side
-        fail_ci_if_error: true
-
   Server_Side_Linting:
     runs-on: ubuntu-18.04
     steps:
@@ -110,9 +101,6 @@ jobs:
       run: |
         cd client
         npm run test
-
-    - name: Upload coverage to Codecov
-      run: bash <(curl -s https://codecov.io/bash) -Z -t ${{ secrets.CODECOV_TOKEN }} -cF javascript
 
   Client_Side_Linting:
     runs-on: ubuntu-18.04

--- a/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
+++ b/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
@@ -17,7 +17,7 @@ function DashboardDisplay() {
     MALTREATMENT[0].field
   ]);
   const [observedFeature, setObservedFeature] = useState(
-    OBSERVED_FEATURES[0].field
+    OBSERVED_FEATURES[4].field /* EP_CROWD */
   );
   const [year, setYear] = useState('2019');
   const [selectedGeographicFeature, setSelectedGeographicFeature] = useState(

--- a/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
+++ b/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
@@ -17,7 +17,9 @@ function DashboardDisplay() {
     MALTREATMENT[0].field
   ]);
   const [observedFeature, setObservedFeature] = useState(
-    OBSERVED_FEATURES[4].field /* EP_CROWD */
+    OBSERVED_FEATURES[3]
+      .field /* EP_CROWD; COOKS-110: EP_CROWD is starting field as we choosing between percent values
+     to begin with */
   );
   const [year, setYear] = useState('2019');
   const [selectedGeographicFeature, setSelectedGeographicFeature] = useState(

--- a/client/src/components/ProTx/components/dashboard/DisplaySelectors.js
+++ b/client/src/components/ProTx/components/dashboard/DisplaySelectors.js
@@ -7,20 +7,9 @@ import {
   OBSERVED_FEATURES_TOP_FIELDS,
   SUPPORTED_YEARS
 } from '../meta';
-import './DisplaySelectors.module.scss';
 
-const compareSimplifiedValueType = (observedFeature, valueType) => {
-  /**
-   * Returns a true if same type (i.e. percent type or non-percent type)
-   *
-   * This is not a valueType direct comparison as we are really considering things as being
-   * percentages or non-percentages.  This is cause we have percents and a variety of yet-to-be-defined
-   * non-percentage value types (like count, dollars etc).
-   */
-  const isPercent =
-    observedFeature.valueType && observedFeature.valueType === 'percent';
-  return valueType === 'percent' ? isPercent : !isPercent;
-};
+import { compareSimplifiedValueType } from '../util';
+import './DisplaySelectors.module.scss';
 
 /* Radio buttons for types of values to display in dropdown (see COOKS-110 for next steps) */
 function ValueTypeSelector({ valueType, setValueType }) {

--- a/client/src/components/ProTx/components/dashboard/DisplaySelectors.module.scss
+++ b/client/src/components/ProTx/components/dashboard/DisplaySelectors.module.scss
@@ -13,3 +13,20 @@
   font-weight: bold;
   padding-right: 0.5rem;
 }
+
+/* TODO Should be reworked in FP-COOKS-110 */
+.radio-container {
+  display: flex;
+  flex-direction: row;
+
+  align-items: center;
+}
+
+.radio-container label {
+  margin-bottom: 0;
+  padding-right: 10px;
+}
+
+.radio-button  {
+    margin-right: 5px;
+}

--- a/client/src/components/ProTx/components/dashboard/DisplaySelectors.module.scss
+++ b/client/src/components/ProTx/components/dashboard/DisplaySelectors.module.scss
@@ -18,7 +18,6 @@
 .radio-container {
   display: flex;
   flex-direction: row;
-
   align-items: center;
 }
 

--- a/client/src/components/ProTx/components/dashboard/DisplaySelectors.module.scss
+++ b/client/src/components/ProTx/components/dashboard/DisplaySelectors.module.scss
@@ -14,7 +14,7 @@
   padding-right: 0.5rem;
 }
 
-/* TODO Should be reworked in FP-COOKS-110 */
+/* TODO Should be reworked in COOKS-110 */
 .radio-container {
   display: flex;
   flex-direction: row;

--- a/client/src/components/ProTx/components/util.js
+++ b/client/src/components/ProTx/components/util.js
@@ -544,6 +544,23 @@ const getObservedFeatureValueType = selectedObservedFeatureCode => {
 };
 
 /**
+ * Compare an observedFeature's valueType with valueType and return  true if same type (i.e. percent type or non-percent type)
+ *
+ * This is not a valueType direct comparison as we are really considering things as being
+ * percentages or non-percentages.  This is cause we have percents and a variety of yet-to-be-defined
+ * non-percentage value types (like count, dollars etc).
+ *
+ * @param {Object} observed feature
+ * @param {String} valueType
+ * @return boolean
+ */
+export const compareSimplifiedValueType = (observedFeature, valueType) => {
+  const isPercent =
+    observedFeature.valueType && observedFeature.valueType === 'percent';
+  return valueType === 'percent' ? isPercent : !isPercent;
+};
+
+/**
  *
  * @param {*} typesDataArray
  * @returns

--- a/client/src/components/ProTx/components/util.js
+++ b/client/src/components/ProTx/components/util.js
@@ -556,7 +556,7 @@ const getObservedFeatureValueType = selectedObservedFeatureCode => {
  */
 export const compareSimplifiedValueType = (observedFeature, valueType) => {
   const isPercent =
-    observedFeature.valueType && observedFeature.valueType === 'percent';
+    'valueType' in observedFeature && observedFeature.valueType === 'percent';
   return valueType === 'percent' ? isPercent : !isPercent;
 };
 

--- a/client/src/components/ProTx/components/utils.test.js
+++ b/client/src/components/ProTx/components/utils.test.js
@@ -1,0 +1,22 @@
+import { compareSimplifiedValueType } from './util';
+
+describe('utili functions', () => {
+  it("perform simplified comparison of valueType to 'percent'", () => {
+    expect(
+      compareSimplifiedValueType({ valueType: 'percent' }, 'percent')
+    ).toEqual(true);
+    expect(compareSimplifiedValueType({}, 'percent')).toEqual(false);
+    expect(
+      compareSimplifiedValueType({ valueType: 'count' }, 'percent')
+    ).toEqual(false);
+  });
+  it("perform simplified comparison of valueType to a non-'percent'", () => {
+    expect(
+      compareSimplifiedValueType({ valueType: 'percent' }, 'count')
+    ).toEqual(false);
+    expect(compareSimplifiedValueType({}, 'count')).toEqual(true);
+    expect(compareSimplifiedValueType({ valueType: 'count' }, 'count')).toEqual(
+      true
+    );
+  });
+});

--- a/client/src/components/ProTx/components/utils.test.js
+++ b/client/src/components/ProTx/components/utils.test.js
@@ -5,6 +5,7 @@ describe('utili functions', () => {
     expect(
       compareSimplifiedValueType({ valueType: 'percent' }, 'percent')
     ).toEqual(true);
+    // unknown types are also not percents
     expect(compareSimplifiedValueType({}, 'percent')).toEqual(false);
     expect(
       compareSimplifiedValueType({ valueType: 'count' }, 'percent')


### PR DESCRIPTION
## Overview: ##

Add option for user to select between percents and counts when viewing demographic variables

## Related Jira tickets: ##

* [COOKS-50](https://jira.tacc.utexas.edu/browse/COOKS-50)

## Testing Steps: ##
1. Go to demographics (https://cep.dev/protx/demographics)
2. Choose between percent and totals
3. Ensure drop down is populated with correct type
4. Ensure that current demographic type is automatically switched 

## UI Photos:
![Screen Shot 2021-08-24 at 8 41 31 AM](https://user-images.githubusercontent.com/8287580/130627207-fdf66786-f7c1-46f5-bf70-127c47717654.png)

## Notes: ##
- Note extra things in follow on ticket [COOKS-110](https://jira.tacc.utexas.edu/browse/COOKS-110)
 (unit tests, select not just first similar variable but the first one that is related etc)