### PR TITLE
COOKS-115:  Remove 'percent' from demographic feature labels

### DIFF
--- a/client/src/components/ProTx/components/data/meta.js
+++ b/client/src/components/ProTx/components/data/meta.js
@@ -17,14 +17,14 @@ export const OBSERVED_FEATURES = [
   { field: 'E_CROWD', name: 'Crowding' },
   {
     field: 'EP_CROWD',
-    name: 'Percent crowding',
+    name: 'Crowding',
     valueType: 'percent',
     valueTypeLabel: 'Percent'
   },
   { field: 'E_DISABL', name: 'Disabled population' },
   {
     field: 'EP_DISABL',
-    name: 'Percent disabled population',
+    name: 'Disabled population',
     valueType: 'percent',
     valueTypeLabel: 'Percent'
   },
@@ -37,14 +37,14 @@ export const OBSERVED_FEATURES = [
   },
   {
     field: 'EP_LIMENG',
-    name: 'Percent population with limited English skills',
+    name: 'Population with limited English skills',
     valueType: 'percent',
     valueTypeLabel: 'Percent'
   },
   { field: 'E_MOBILE', name: 'Mobile homes' },
   {
     field: 'EP_MOBILE',
-    name: 'Percent mobile homes',
+    name: 'Mobile homes',
     valueType: 'percent',
     valueTypeLabel: 'Percent'
   },
@@ -55,14 +55,14 @@ export const OBSERVED_FEATURES = [
   },
   {
     field: 'EP_NOHSDP',
-    name: 'Percent population with no high school diploma',
+    name: 'Population with no high school diploma',
     valueType: 'percent',
     valueTypeLabel: 'Percent'
   },
   { field: 'E_NOVEH', name: 'Households with no vehicle' },
   {
     field: 'EP_NOVEH',
-    name: 'Percent households with no vehicle',
+    name: 'Households with no vehicle',
     valueType: 'percent',
     valueTypeLabel: 'Percent'
   },
@@ -70,7 +70,7 @@ export const OBSERVED_FEATURES = [
   { field: 'E_POV', name: 'Population below poverty threshold' },
   {
     field: 'EP_POV',
-    name: 'Percent population below poverty threshold',
+    name: 'Population below poverty threshold',
     valueType: 'percent',
     valueTypeLabel: 'Percent'
   },
@@ -79,14 +79,14 @@ export const OBSERVED_FEATURES = [
   { field: 'E_UNEMP', name: 'Unemployed population' },
   {
     field: 'EP_UNEMP',
-    name: 'Percent unemployed population',
+    name: 'Unemployed population',
     valueType: 'percent',
     valueTypeLabel: 'Percent'
   },
   { field: 'E_UNINSUR', name: 'Uninsured population' },
   {
     field: 'EP_UNINSUR',
-    name: 'Percent uninsured population',
+    name: 'Uninsured population',
     valueType: 'percent',
     valueTypeLabel: 'Percent'
   },
@@ -97,7 +97,7 @@ export const OBSERVED_FEATURES = [
   },
   {
     field: `E_FOREIGN_BORN_P`,
-    name: `Percent foreign born population`,
+    name: `Foreign born population`,
     valueType: 'percent',
     valueTypeLabel: 'Percent'
   },
@@ -107,7 +107,7 @@ export const OBSERVED_FEATURES = [
   },
   {
     field: `E_RENTER_OCCUPIED_HOUSING_UNITS_P`,
-    name: `Percent renter-occupied housing units`,
+    name: `Renter-occupied housing units`,
     valueType: 'percent',
     valueTypeLabel: 'Percent'
   },


### PR DESCRIPTION
## Overview: ##

Remove percent from demographic feature labels


## Related Jira tickets: ##

* [COOKS-115](https://jira.tacc.utexas.edu/browse/COOKS-115)

## Summary of Changes: ##

## Testing Steps: ##
1. Go to https://cep.dev/protx/demographics
2. Click on percents and then ensure all labels no longer have the word "percent"

## UI Photos:

<img width="621" alt="Screen Shot 2021-09-03 at 10 11 42 AM" src="https://user-images.githubusercontent.com/8287580/132028933-4eae7ae2-b329-473f-bf4b-df1c1d99b020.png">
