### PR TITLE
Task/cooks 26 color scale improvements

### DIFF
--- a/client/src/components/ProTx/components/data/colors.js
+++ b/client/src/components/ProTx/components/data/colors.js
@@ -5,7 +5,7 @@ const colorbrewerClassYlOrBr = {
   4: ['#ffffd4', '#fed98e', '#fe9929', '#cc4c02'],
   3: [`#fff7bc`, `#fec44f`, `#d95f0e`],
   2: [`#fff7bc`, `#fec44f`],
-  1: [`#fff7bc`, `#fec44f`]
+  1: [`#fff7bc`]
 };
 
 const THEME_CB12_MAIN = [

--- a/client/src/components/ProTx/components/data/colors.js
+++ b/client/src/components/ProTx/components/data/colors.js
@@ -1,11 +1,12 @@
-const colorbrewerClass6YlOrBr = [
-  '#ffffd4',
-  '#fee391',
-  '#fec44f',
-  '#fe9929',
-  '#d95f0e',
-  '#993404'
-];
+const colorbrewerClassYlOrBr = {
+  /* derived from https://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=6 */
+  6: ['#ffffd4', '#fee391', '#fec44f', '#fe9929', '#d95f0e', '#993404'],
+  5: ['#ffffd4', '#fed98e', '#fe9929', '#d95f0e', '#993404'],
+  4: ['#ffffd4', '#fed98e', '#fe9929', '#cc4c02'],
+  3: [`#fff7bc`, `#fec44f`, `#d95f0e`],
+  2: [`#fff7bc`, `#fec44f`],
+  1: [`#fff7bc`, `#fec44f`]
+};
 
 const THEME_CB12_MAIN = [
   '#4363d8',
@@ -83,7 +84,7 @@ const THEME_CB12_ALT3 = [
 ];
 
 export {
-  colorbrewerClass6YlOrBr,
+  colorbrewerClassYlOrBr,
   THEME_CB12_MAIN,
   THEME_CB12_ALT0,
   THEME_CB12_ALT1,

--- a/client/src/components/ProTx/components/data/meta.js
+++ b/client/src/components/ProTx/components/data/meta.js
@@ -18,15 +18,13 @@ export const OBSERVED_FEATURES = [
   {
     field: 'EP_CROWD',
     name: 'Percent crowding',
-    valueType: 'percent',
-    valueTypeLabel: 'Percent'
+    valueType: 'percent'
   },
   { field: 'E_DISABL', name: 'Disabled population' },
   {
     field: 'EP_DISABL',
     name: 'Percent disabled population',
-    valueType: 'percent',
-    valueTypeLabel: 'Percent'
+    valueType: 'percent'
   },
   { field: 'E_GROUPQ', name: 'Population living in group quarters' },
   { field: 'E_HH', name: 'Households' },
@@ -38,8 +36,7 @@ export const OBSERVED_FEATURES = [
   {
     field: 'EP_LIMENG',
     name: 'Percent population with limited English skills',
-    valueType: 'percent',
-    valueTypeLabel: 'Percent'
+    valueType: 'percent'
   },
   { field: 'E_MOBILE', name: 'Mobile homes' },
   {
@@ -56,23 +53,20 @@ export const OBSERVED_FEATURES = [
   {
     field: 'EP_NOHSDP',
     name: 'Percent population with no high school diploma',
-    valueType: 'percent',
-    valueTypeLabel: 'Percent'
+    valueType: 'percent'
   },
   { field: 'E_NOVEH', name: 'Households with no vehicle' },
   {
     field: 'EP_NOVEH',
     name: 'Percent households with no vehicle',
-    valueType: 'percent',
-    valueTypeLabel: 'Percent'
+    valueType: 'percent'
   },
   { field: 'E_PCI', name: 'Per capita income' },
   { field: 'E_POV', name: 'Population below poverty threshold' },
   {
     field: 'EP_POV',
     name: 'Percent population below poverty threshold',
-    valueType: 'percent',
-    valueTypeLabel: 'Percent'
+    valueType: 'percent'
   },
   { field: 'E_SNGPNT', name: 'Single parent households' },
   { field: 'E_TOTPOP', name: 'Total population' },
@@ -80,15 +74,13 @@ export const OBSERVED_FEATURES = [
   {
     field: 'EP_UNEMP',
     name: 'Percent unemployed population',
-    valueType: 'percent',
-    valueTypeLabel: 'Percent'
+    valueType: 'percent'
   },
   { field: 'E_UNINSUR', name: 'Uninsured population' },
   {
     field: 'EP_UNINSUR',
     name: 'Percent uninsured population',
-    valueType: 'percent',
-    valueTypeLabel: 'Percent'
+    valueType: 'percent'
   },
   { field: 'E_MINRTY', name: 'Minority population' },
   {
@@ -98,8 +90,7 @@ export const OBSERVED_FEATURES = [
   {
     field: `E_FOREIGN_BORN_P`,
     name: `Percent foreign born population`,
-    valueType: 'percent',
-    valueTypeLabel: 'Percent'
+    valueType: 'percent'
   },
   {
     field: `E_RENTER_OCCUPIED_HOUSING_UNITS`,
@@ -108,14 +99,12 @@ export const OBSERVED_FEATURES = [
   {
     field: `E_RENTER_OCCUPIED_HOUSING_UNITS_P`,
     name: `Percent renter-occupied housing units`,
-    valueType: 'percent',
-    valueTypeLabel: 'Percent'
+    valueType: 'percent'
   },
   {
     field: `E_MEDIAN_GROSS_RENT_P`,
     name: `Median gross rent as a percentage of household income`,
-    valueType: 'percent',
-    valueTypeLabel: 'Percent'
+    valueType: 'percent'
   }
 ];
 
@@ -136,26 +125,22 @@ export const MALTREATMENT = [
   {
     field: 'ABAN',
     name: 'Abandonment',
-    valueType: 'count',
-    valueTypeLabel: 'Count'
+    valueType: 'count'
   },
   {
     field: 'EMAB',
     name: 'Emotional abuse',
-    valueType: 'count',
-    valueTypeLabel: 'Count'
+    valueType: 'count'
   },
   {
     field: 'LBTR',
     name: 'Labor trafficking',
-    valueType: 'count',
-    valueTypeLabel: 'Count'
+    valueType: 'count'
   },
   {
     field: 'MDNG',
     name: 'Medical neglect',
-    valueType: 'count',
-    valueTypeLabel: 'Count'
+    valueType: 'count'
   },
   {
     field: 'NSUP',
@@ -166,32 +151,27 @@ export const MALTREATMENT = [
   {
     field: 'PHAB',
     name: 'Physical abuse',
-    valueType: 'count',
-    valueTypeLabel: 'Count'
+    valueType: 'count'
   },
   {
     field: 'PHNG',
     name: 'Physical neglect',
-    valueType: 'count',
-    valueTypeLabel: 'Count'
+    valueType: 'count'
   },
   {
     field: 'RAPR',
     name: 'Refusal to accept parental responsibility',
-    valueType: 'count',
-    valueTypeLabel: 'Count'
+    valueType: 'count'
   },
   {
     field: 'SXAB',
     name: 'Sexual abuse',
-    valueType: 'count',
-    valueTypeLabel: 'Count'
+    valueType: 'count'
   },
   {
     field: 'SXTR',
     name: 'Sex trafficking',
-    valueType: 'count',
-    valueTypeLabel: 'Count'
+    valueType: 'count'
   }
 ];
 

--- a/client/src/components/ProTx/components/maps/MainMap.css
+++ b/client/src/components/ProTx/components/maps/MainMap.css
@@ -8,6 +8,15 @@
 .legend {
   line-height: 10px;
 }
+
+.legend-title{
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-normal-plus);
+  min-width: 100px;
+  text-align: center;
+  padding-bottom: 10px;
+}
+
 .scale-value * {
   vertical-align: sub;
 }

--- a/client/src/components/ProTx/components/maps/MainMap.css
+++ b/client/src/components/ProTx/components/maps/MainMap.css
@@ -12,9 +12,10 @@
 .legend-title{
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-normal-plus);
-  min-width: 100px;
+  width: 100px;
   text-align: center;
   padding-bottom: 10px;
+  line-height: 16px;
 }
 
 .scale-value * {

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -8,10 +8,13 @@ import { GEOID_KEY } from '../data/meta';
 import './MainMap.css';
 import './MainMap.module.scss';
 import 'leaflet/dist/leaflet.css';
-import { getMetaData } from '../shared/dataUtils';
+import {
+  getMetaData,
+  getMaltreatmentLabel,
+  getObservedFeaturesLabel
+} from '../shared/dataUtils';
 import getFeatureStyle from '../shared/mapUtils';
 import IntervalColorScale from '../shared/colorsUtils';
-
 
 let mapContainer;
 
@@ -33,7 +36,6 @@ function MainMap({
   const [dataLayer, setDataLayer] = useState(null);
   const [texasOutlineLayer, setTexasOutlineLayer] = useState(null);
   const [map, setMap] = useState(null);
-  const [metaData, setMetaData] = useState(null);
   const [colorScale, setColorScale] = useState(null);
   const [selectedGeoid, setSelectedGeoid] = useState(null);
 
@@ -105,26 +107,22 @@ function MainMap({
       setColorScale(intervalColorScale);
 
       if (intervalColorScale) {
+        const label =
+          mapType === 'maltreatment'
+            ? getMaltreatmentLabel(maltreatmentTypes)
+            : getObservedFeaturesLabel(observedFeature);
+
         const newLegend = L.control({ position: 'bottomright' });
 
         newLegend.onAdd = () => {
           const div = L.DomUtil.create('div', 'color legend');
-
+          div.innerHTML += `<div class="legend-title">${label}</div>`;
           // get numeric values between intervals
-          const intervalValues = intervalColorScale.getIntervalValues();
-          const scaleRoundingValue = 0;
-
+          const intervalLabels = intervalColorScale.getIntervalLabels();
           // loop through our density intervals and generate a label with a colored square for each interval
           for (let i = 0; i < intervalColorScale.numberIntervals; i += 1) {
-            div.innerHTML += `<div class="scale-value"><i style="background:${
-              intervalColorScale.colors[i]
-            }"></i> <span>${intervalValues[i].toFixed(
-              scaleRoundingValue
-            )}&ndash;${intervalValues[i + 1].toFixed(
-              scaleRoundingValue
-            )}</span></div><br>`;
+            div.innerHTML += `<div class="scale-value"><i style="background:${intervalColorScale.colors[i]}"></i> <span>${intervalLabels[i]}</span></div><br>`;
           }
-
           return div;
         };
         // add new data layer to map and controls

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -118,10 +118,9 @@ function MainMap({
           const div = L.DomUtil.create('div', 'color legend');
           div.innerHTML += `<div class="legend-title">${label}</div>`;
           // get numeric values between intervals
-          const intervalLabels = intervalColorScale.getIntervalLabels();
           // loop through our density intervals and generate a label with a colored square for each interval
           for (let i = 0; i < intervalColorScale.numberIntervals; i += 1) {
-            div.innerHTML += `<div class="scale-value"><i style="background:${intervalColorScale.colors[i]}"></i> <span>${intervalLabels[i]}</span></div><br>`;
+            div.innerHTML += `<div class="scale-value"><i style="background:${intervalColorScale.colors[i]}"></i> <span>${intervalColorScale.intervalLabels[i]}</span></div><br>`;
           }
           return div;
         };

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -9,7 +9,9 @@ import './MainMap.css';
 import './MainMap.module.scss';
 import 'leaflet/dist/leaflet.css';
 import { getMetaData } from '../shared/dataUtils';
-import { IntervalColorScale, getFeatureStyle } from '../shared/mapUtils';
+import getFeatureStyle from '../shared/mapUtils';
+import IntervalColorScale from '../shared/colorsUtils';
+
 
 let mapContainer;
 
@@ -32,6 +34,7 @@ function MainMap({
   const [texasOutlineLayer, setTexasOutlineLayer] = useState(null);
   const [map, setMap] = useState(null);
   const [metaData, setMetaData] = useState(null);
+  const [colorScale, setColorScale] = useState(null);
   const [selectedGeoid, setSelectedGeoid] = useState(null);
 
   const refSelectedGeoid = useRef(selectedGeoid); // Make a ref of the selected feature
@@ -97,24 +100,24 @@ function MainMap({
         observedFeature,
         maltreatmentTypes
       );
-      // set for use by vector layer
-      setMetaData(meta);
 
-      if (meta) {
+      const intervalColorScale = meta ? new IntervalColorScale(meta) : null;
+      setColorScale(intervalColorScale);
+
+      if (intervalColorScale) {
         const newLegend = L.control({ position: 'bottomright' });
 
         newLegend.onAdd = () => {
           const div = L.DomUtil.create('div', 'color legend');
 
           // get numeric values between intervals
-          const colorScale = new IntervalColorScale(meta);
-          const intervalValues = colorScale.getIntervalValues();
+          const intervalValues = intervalColorScale.getIntervalValues();
           const scaleRoundingValue = 0;
 
           // loop through our density intervals and generate a label with a colored square for each interval
-          for (let i = 0; i < colorScale.numberIntervals; i += 1) {
+          for (let i = 0; i < intervalColorScale.numberIntervals; i += 1) {
             div.innerHTML += `<div class="scale-value"><i style="background:${
-              colorScale.colors[i]
+              intervalColorScale.colors[i]
             }"></i> <span>${intervalValues[i].toFixed(
               scaleRoundingValue
             )}&ndash;${intervalValues[i + 1].toFixed(
@@ -150,7 +153,7 @@ function MainMap({
             return getFeatureStyle(
               mapType,
               data,
-              metaData,
+              colorScale,
               geography,
               year,
               geoid,
@@ -187,7 +190,7 @@ function MainMap({
             ...getFeatureStyle(
               mapType,
               data,
-              metaData,
+              colorScale,
               geography,
               year,
               clickedGeographicFeature,
@@ -223,7 +226,7 @@ function MainMap({
           ...getFeatureStyle(
             mapType,
             data,
-            metaData,
+            colorScale,
             geography,
             year,
             selectedGeographicFeature,
@@ -245,7 +248,7 @@ function MainMap({
     }
   }, [
     data,
-    metaData,
+    colorScale,
     mapType,
     geography,
     observedFeature,

--- a/client/src/components/ProTx/components/shared/colorsUtils.js
+++ b/client/src/components/ProTx/components/shared/colorsUtils.js
@@ -9,27 +9,48 @@ import { colorbrewerClassYlOrBr } from '../data/colors';
 class IntervalColorScale {
   constructor(meta) {
     this.meta = meta;
+    let singleValueClasses = false;
+
     if (meta.min === meta.max) {
       this.numberIntervals = 1;
     } else if (Number.isInteger(meta.min) && Number.isInteger(meta.max)) {
       const numberPossibleClasses = meta.max - meta.min + 1;
+      if (numberPossibleClasses <= 6) {
+        singleValueClasses = true;
+      }
       this.numberIntervals = Math.min(numberPossibleClasses, 6);
     } else {
       this.numberIntervals = 6;
     }
     this.colors = colorbrewerClassYlOrBr[this.numberIntervals];
+
+    this.intervalValues = [this.meta.min];
+    for (let i = 1; i < this.numberIntervals; i += 1) {
+      this.intervalValues.push(
+        this.meta.min +
+          (i * (this.meta.max - this.meta.min)) / this.numberIntervals
+      );
+    }
+    this.intervalValues.push(this.meta.max);
+
+    this.intervalLabels = [];
+    const scaleRoundingValue = 0;
+    for (let i = 0; i < this.numberIntervals; i += 1) {
+      const startValue = this.intervalValues[i].toFixed(scaleRoundingValue);
+      const nextValue = this.intervalValues[i + 1].toFixed(scaleRoundingValue);
+      const label = singleValueClasses
+        ? `${startValue}`
+        : `${startValue} - ${nextValue}`;
+      this.intervalLabels.push(label);
+    }
   }
 
   getIntervalValues() {
-    const intervalValues = [this.meta.min];
-    for (let i = 1; i < this.numberIntervals; i += 1) {
-      intervalValues.push(
-        this.meta.min +
-        (i * (this.meta.max - this.meta.min)) / this.numberIntervals
-      );
-    }
-    intervalValues.push(this.meta.max);
-    return intervalValues;
+    return this.intervalValues;
+  }
+
+  getIntervalLabels() {
+    return this.intervalLabels;
   }
 
   getColor(value) {

--- a/client/src/components/ProTx/components/shared/colorsUtils.js
+++ b/client/src/components/ProTx/components/shared/colorsUtils.js
@@ -11,9 +11,10 @@ class IntervalColorScale {
     this.meta = meta;
     let singleValueClasses = false;
 
-    if (meta.min === meta.max) {
-      this.numberIntervals = 1;
-    } else if (Number.isInteger(meta.min) && Number.isInteger(meta.max)) {
+    if (
+      meta.min === meta.max ||
+      (Number.isInteger(meta.min) && Number.isInteger(meta.max))
+    ) {
       const numberPossibleClasses = meta.max - meta.min + 1;
       if (numberPossibleClasses <= 6) {
         singleValueClasses = true;
@@ -24,33 +25,33 @@ class IntervalColorScale {
     }
     this.colors = colorbrewerClassYlOrBr[this.numberIntervals];
 
-    this.intervalValues = [this.meta.min];
-    for (let i = 1; i < this.numberIntervals; i += 1) {
-      this.intervalValues.push(
-        this.meta.min +
-          (i * (this.meta.max - this.meta.min)) / this.numberIntervals
-      );
+    const intervalValues = [];
+    if (singleValueClasses) {
+      for (let i = 0; i < this.numberIntervals; i += 1) {
+        intervalValues.push(this.meta.min + i);
+      }
+      intervalValues.push(this.meta.max);
+    } else {
+      intervalValues.push(this.meta.min);
+      for (let i = 1; i < this.numberIntervals; i += 1) {
+        intervalValues.push(
+          this.meta.min +
+            (i * (this.meta.max - this.meta.min)) / this.numberIntervals
+        );
+      }
+      intervalValues.push(this.meta.max);
     }
-    this.intervalValues.push(this.meta.max);
 
     this.intervalLabels = [];
     const scaleRoundingValue = 0;
     for (let i = 0; i < this.numberIntervals; i += 1) {
-      const startValue = this.intervalValues[i].toFixed(scaleRoundingValue);
-      const nextValue = this.intervalValues[i + 1].toFixed(scaleRoundingValue);
+      const startValue = intervalValues[i].toFixed(scaleRoundingValue);
+      const nextValue = intervalValues[i + 1].toFixed(scaleRoundingValue);
       const label = singleValueClasses
         ? `${startValue}`
         : `${startValue} - ${nextValue}`;
       this.intervalLabels.push(label);
     }
-  }
-
-  getIntervalValues() {
-    return this.intervalValues;
-  }
-
-  getIntervalLabels() {
-    return this.intervalLabels;
   }
 
   getColor(value) {

--- a/client/src/components/ProTx/components/shared/colorsUtils.js
+++ b/client/src/components/ProTx/components/shared/colorsUtils.js
@@ -55,13 +55,16 @@ class IntervalColorScale {
   }
 
   getColor(value) {
-    const binValue = Math.min(
-      Math.floor(
-        this.numberIntervals *
-          ((value - this.meta.min) / (this.meta.max - this.meta.min))
-      ),
-      this.numberIntervals - 1
-    );
+    const binValue =
+      this.numberIntervals === 1
+        ? 0
+        : Math.min(
+            Math.floor(
+              this.numberIntervals *
+                ((value - this.meta.min) / (this.meta.max - this.meta.min))
+            ),
+            this.numberIntervals - 1
+          );
     return this.colors[binValue];
   }
 }

--- a/client/src/components/ProTx/components/shared/colorsUtils.js
+++ b/client/src/components/ProTx/components/shared/colorsUtils.js
@@ -1,0 +1,47 @@
+import { colorbrewerClassYlOrBr } from '../data/colors';
+
+/** Interval color scale
+
+ Translate values to color and provide information about range of colors (and there intervals) based
+ upon information about a variable (min, max, type, special formatting properties etc).
+
+ */
+class IntervalColorScale {
+  constructor(meta) {
+    this.meta = meta;
+    if (meta.min === meta.max) {
+      this.numberIntervals = 1;
+    } else if (Number.isInteger(meta.min) && Number.isInteger(meta.max)) {
+      const numberPossibleClasses = meta.max - meta.min + 1;
+      this.numberIntervals = Math.min(numberPossibleClasses, 6);
+    } else {
+      this.numberIntervals = 6;
+    }
+    this.colors = colorbrewerClassYlOrBr[this.numberIntervals];
+  }
+
+  getIntervalValues() {
+    const intervalValues = [this.meta.min];
+    for (let i = 1; i < this.numberIntervals; i += 1) {
+      intervalValues.push(
+        this.meta.min +
+        (i * (this.meta.max - this.meta.min)) / this.numberIntervals
+      );
+    }
+    intervalValues.push(this.meta.max);
+    return intervalValues;
+  }
+
+  getColor(value) {
+    const binValue = Math.min(
+      Math.floor(
+        this.numberIntervals *
+          ((value - this.meta.min) / (this.meta.max - this.meta.min))
+      ),
+      this.numberIntervals - 1
+    );
+    return this.colors[binValue];
+  }
+}
+
+export default IntervalColorScale;

--- a/client/src/components/ProTx/components/shared/colorsUtils.test.js
+++ b/client/src/components/ProTx/components/shared/colorsUtils.test.js
@@ -1,0 +1,81 @@
+import IntervalColorScale from '../shared/colorsUtils';
+import { colorbrewerClassYlOrBr } from '../data/colors';
+
+describe('IntervalColorScale', () => {
+  it('handle for single integer class', () => {
+    const meta = {min:1, max:1};
+    const colorScale = new IntervalColorScale(meta)
+    expect(colorScale.numberIntervals).toEqual(1);
+    expect(colorScale.intervalLabels).toEqual(['1']);
+    /*TODO expect(colorScale.getColor(1)).toEqual(colorbrewerClassYlOrBr[1][0]); */
+  });
+  it('handle 2 integer classes', () => {
+    const meta = {min:1, max:2};
+    const colorScale = new IntervalColorScale(meta)
+    expect(colorScale.numberIntervals).toEqual(2);
+    expect(colorScale.intervalLabels).toEqual(['1', '2']);
+    expect(colorScale.getColor(1)).toEqual(colorbrewerClassYlOrBr[2][0]);
+    expect(colorScale.getColor(2)).toEqual(colorbrewerClassYlOrBr[2][1]);
+  });
+  it('handle 3 integer classes', () => {
+    const meta = {min:1, max:3};
+    const colorScale = new IntervalColorScale(meta);
+    expect(colorScale.numberIntervals).toEqual(3);
+    expect(colorScale.intervalLabels).toEqual(['1', '2', '3']);
+    expect(colorScale.getColor(1)).toEqual(colorbrewerClassYlOrBr[3][0]);
+    expect(colorScale.getColor(2)).toEqual(colorbrewerClassYlOrBr[3][1]);
+    expect(colorScale.getColor(3)).toEqual(colorbrewerClassYlOrBr[3][2]);
+  });
+  it('handle 4 integer classes', () => {
+    const meta = {min:1, max:4};
+    const colorScale = new IntervalColorScale(meta);
+    expect(colorScale.numberIntervals).toEqual(4);
+    expect(colorScale.intervalLabels).toEqual(['1', '2', '3', '4']);
+    expect(colorScale.getColor(1)).toEqual(colorbrewerClassYlOrBr[4][0]);
+    expect(colorScale.getColor(2)).toEqual(colorbrewerClassYlOrBr[4][1]);
+    expect(colorScale.getColor(3)).toEqual(colorbrewerClassYlOrBr[4][2]);
+    expect(colorScale.getColor(4)).toEqual(colorbrewerClassYlOrBr[4][3]);
+  });
+  it('handle 5 integer classes', () => {
+    const meta = {min:1, max:5};
+    const colorScale = new IntervalColorScale(meta);
+    expect(colorScale.numberIntervals).toEqual(5);
+    expect(colorScale.intervalLabels).toEqual(['1', '2', '3', '4', '5',]);
+    expect(colorScale.getColor(1)).toEqual(colorbrewerClassYlOrBr[5][0]);
+    expect(colorScale.getColor(2)).toEqual(colorbrewerClassYlOrBr[5][1]);
+    expect(colorScale.getColor(3)).toEqual(colorbrewerClassYlOrBr[5][2]);
+    expect(colorScale.getColor(4)).toEqual(colorbrewerClassYlOrBr[5][3]);
+    expect(colorScale.getColor(5)).toEqual(colorbrewerClassYlOrBr[5][4]);
+  });
+  it('handle 6 integer classes', () => {
+    const meta = {min:1, max:6};
+    const colorScale = new IntervalColorScale(meta);
+    expect(colorScale.numberIntervals).toEqual(6);
+    expect(colorScale.intervalLabels).toEqual(['1', '2', '3', '4', '5', '6']);
+    expect(colorScale.getColor(1)).toEqual(colorbrewerClassYlOrBr[6][0]);
+    expect(colorScale.getColor(2)).toEqual(colorbrewerClassYlOrBr[6][1]);
+    expect(colorScale.getColor(3)).toEqual(colorbrewerClassYlOrBr[6][2]);
+    expect(colorScale.getColor(4)).toEqual(colorbrewerClassYlOrBr[6][3]);
+    expect(colorScale.getColor(5)).toEqual(colorbrewerClassYlOrBr[6][4]);
+    expect(colorScale.getColor(6)).toEqual(colorbrewerClassYlOrBr[6][5]);
+  });
+  it('handle normal 6 class range', () => {
+    const meta = {min:0, max:60};
+    const colorScale = new IntervalColorScale(meta);
+    expect(colorScale.numberIntervals).toEqual(6);
+    expect(colorScale.intervalLabels).toEqual(['0 - 10', '10 - 20', '20 - 30', '30 - 40', '40 - 50', '50 - 60']);
+    expect(colorScale.getColor(0.0)).toEqual(colorbrewerClassYlOrBr[6][0]);
+    expect(colorScale.getColor(9.9)).toEqual(colorbrewerClassYlOrBr[6][0]);
+
+    expect(colorScale.getColor(10)).toEqual(colorbrewerClassYlOrBr[6][1]);
+    expect(colorScale.getColor(19.9)).toEqual(colorbrewerClassYlOrBr[6][1]);
+
+    expect(colorScale.getColor(20)).toEqual(colorbrewerClassYlOrBr[6][2]);
+    expect(colorScale.getColor(30)).toEqual(colorbrewerClassYlOrBr[6][3]);
+    expect(colorScale.getColor(40)).toEqual(colorbrewerClassYlOrBr[6][4]);
+
+    expect(colorScale.getColor(50)).toEqual(colorbrewerClassYlOrBr[6][5]);
+    expect(colorScale.getColor(60)).toEqual(colorbrewerClassYlOrBr[6][5]);
+
+  });
+});

--- a/client/src/components/ProTx/components/shared/colorsUtils.test.js
+++ b/client/src/components/ProTx/components/shared/colorsUtils.test.js
@@ -7,7 +7,15 @@ describe('IntervalColorScale', () => {
     const colorScale = new IntervalColorScale(meta)
     expect(colorScale.numberIntervals).toEqual(1);
     expect(colorScale.intervalLabels).toEqual(['1']);
-    /*TODO expect(colorScale.getColor(1)).toEqual(colorbrewerClassYlOrBr[1][0]); */
+    const value = 1;
+    const binValue = Math.min(
+      Math.floor(
+        colorScale.numberIntervals *
+        ((value - colorScale.meta.min) / (colorScale.meta.max - colorScale.meta.min))
+      ),
+      colorScale.numberIntervals - 1
+    );
+    expect(colorScale.getColor(1)).toEqual(colorbrewerClassYlOrBr[1][0]);
   });
   it('handle 2 integer classes', () => {
     const meta = {min:1, max:2};

--- a/client/src/components/ProTx/components/shared/dataUtils.js
+++ b/client/src/components/ProTx/components/shared/dataUtils.js
@@ -125,7 +125,10 @@ const getMaltreatmentMetaData = (data, geography, year, maltreatmentTypes) => {
 
     const values = Object.values(aggregrateValues).map(x => +x);
     if (values.length) {
-      meta = { min: Math.min(...values), max: Math.max(...values) };
+      meta = {
+        min: Math.min(...values),
+        max: Math.max(...values)
+      };
     }
   }
   return meta;
@@ -215,6 +218,7 @@ const getMaltreatmentAggregatedValue = (
 };
 
 /**
+ *  Get list of maltreatment display names
  *
  * @param {*} typesDataArray
  * @returns
@@ -270,6 +274,14 @@ const getMaltreatmentSelectedValues = (
 };
 
 /**
+ * Get label for selected maltreatment types
+ * @param Array<{String}> maltreatmentTypes
+ */
+const getMaltreatmentLabel = maltreatmentTypes => {
+  return maltreatmentTypes.length > 1 ? 'Aggregated Count' : 'Count';
+};
+
+/**
  *
  * @param {*} typesDataArray
  * @returns
@@ -287,10 +299,10 @@ const getMaltreatmentTypesDataObject = (codeArray, nameArray, valueArray) => {
   return newMaltreatmentDataObject;
 };
 
-/**
+/** Get display label for selected observed feature
  *
- * @param {*} typesDataArray
- * @returns
+ * @param selectedObservedFeatureCode:str code of feature
+ * @returns label
  */
 const getObservedFeaturesLabel = selectedObservedFeatureCode => {
   return OBSERVED_FEATURES.find(f => selectedObservedFeatureCode === f.field)
@@ -335,6 +347,7 @@ export {
   getFipsIdName,
   getMaltreatmentTypeNames,
   getMaltreatmentSelectedValues,
+  getMaltreatmentLabel,
   getMaltreatmentTypesDataObject,
   getObservedFeaturesLabel,
   getObservedFeatureValueType,

--- a/client/src/components/ProTx/components/shared/mapUtils.js
+++ b/client/src/components/ProTx/components/shared/mapUtils.js
@@ -2,51 +2,16 @@ import {
   getObservedFeatureValue,
   getMaltreatmentAggregatedValue
 } from './dataUtils';
-import { colorbrewerClass6YlOrBr } from '../data/colors';
-
-const colorsArray = colorbrewerClass6YlOrBr;
-
-/** Interval color scale
-
- Translate values to color and provide information about range of colors (and there intervals) based
- upon information about a variable (min, max, type, special formatting properties etc).
-
- TODO extended to handle percents, integers, human readability: https://jira.tacc.utexas.edu/browse/COOKS-26
-*/
-class IntervalColorScale {
-  constructor(meta) {
-    this.meta = meta;
-    this.colors = colorsArray;
-    this.numberIntervals = colorsArray.length;
-  }
-
-  getIntervalValues() {
-    const intervalValues = [this.meta.min];
-    for (let i = 1; i < this.numberIntervals; i += 1) {
-      intervalValues.push(
-        this.meta.min +
-          (i * (this.meta.max - this.meta.min)) / this.numberIntervals
-      );
-    }
-    intervalValues.push(this.meta.max);
-    return intervalValues;
-  }
-}
-
-// TODO moved into IntervalColorScale
-export function getColor(value, min, max) {
-  const binValue = Math.min(Math.floor(6 * ((value - min) / (max - min))), 5);
-  return colorsArray[binValue];
-}
 
 /**
  * Get style for feature
  *
- * If no value exists, then we return a transparent feature style if no value exists)
+ * If no value exists, then we return a transparent feature style.  Same if no color scale as
+ * that implies no data
  *
  * @param {String} mapType
  * @param {Object} data
- * @param {Object} metaData
+ * @param {Object} colorScale
  * @param {String} geography
  * @param {Number} year
  * @param {Number} geoid
@@ -57,7 +22,7 @@ export function getColor(value, min, max) {
 const getFeatureStyle = (
   mapType,
   data,
-  metaData,
+  colorScale,
   geography,
   year,
   geoid,
@@ -73,8 +38,8 @@ const getFeatureStyle = (
       geoid,
       observedFeature
     );
-    if (featureValue && metaData) {
-      fillColor = getColor(featureValue, metaData.min, metaData.max);
+    if (featureValue && colorScale) {
+      fillColor = colorScale.getColor(featureValue);
     }
   } else {
     const featureValue = getMaltreatmentAggregatedValue(
@@ -84,8 +49,8 @@ const getFeatureStyle = (
       geoid,
       maltreatmentTypes
     );
-    if (featureValue !== 0 && metaData) {
-      fillColor = getColor(featureValue, metaData.min, metaData.max);
+    if (featureValue !== 0 && colorScale) {
+      fillColor = colorScale.getColor(featureValue);
     }
   }
   if (fillColor) {
@@ -106,4 +71,4 @@ const getFeatureStyle = (
   };
 };
 
-export { getFeatureStyle, IntervalColorScale };
+export default getFeatureStyle;


### PR DESCRIPTION
## Overview: ##

Improves color scale legend

## Related Jira tickets: ##

* [COOKS-26](https://jira.tacc.utexas.edu/browse/COOKS-26)
* [COOKS-89](https://jira.tacc.utexas.edu/browse/COOKS-89)

## Summary of Changes: ##
Add label to top of color scale
Improves classes to support less than 6 classes
Improves labels for classes that correspond to discreat values (and not a number range)
Adds unit (currently just percentage, %)

## Testing Steps: ##
1. View all three views (maltreatment, demographics and analysis)
2. Switch people each data type and count/percentage
3. Switch between years
4. Ensure that you also see scenarios with less than 6 classes

## UI Photos:

TODO

## Notes: ##
TODO:
- [ ] Add percentage ("%) on color scale labels