### PR TITLE
Cooks 155 add resources data endpoint

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12972,6 +12972,11 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
       "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw=="
     },
+    "leaflet.markercluster": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA=="
+    },
     "leaflet.vectorgrid": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/leaflet.vectorgrid/-/leaflet.vectorgrid-1.3.0.tgz",
@@ -15174,8 +15179,7 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "1.8.0",

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
     "jquery": "^3.6.0",
     "js-cookie": "^2.2.1",
     "leaflet": "^1.7.1",
+    "leaflet.markercluster": "^1.5.3",
     "leaflet.vectorgrid": "^1.3.0",
     "lodash": "^4.17.21",
     "mock-socket": "^9.0.3",

--- a/client/src/components/ProTx/components/maps/MainMap.css
+++ b/client/src/components/ProTx/components/maps/MainMap.css
@@ -1,4 +1,6 @@
 @import '~leaflet/dist/leaflet.css';
+@import '~leaflet.markercluster/dist/MarkerCluster.css';
+@import '~leaflet.markercluster/dist/MarkerCluster.Default.css';
 
 .color {
   padding: 1rem 1rem 0.5rem;

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -175,15 +175,6 @@ function MainMap({
 
       map.addLayer(markersClusterGroup);
       layersControl.addOverlay(markersClusterGroup, 'Resources');
-      // save this layer?
-
-      // TODO
-      // - where i am at:  make marker with values etc
-      // - layer for each of the categories
-      // - placeholder for only showing data for the current year (i.e. add year to effect and check boolean)
-
-      // ensure that texas outline is on top
-      // texasOutlineLayer.bringToFront();
     }
   }, [layersControl, map, resources]);
 

--- a/client/src/redux/sagas/protx.sagas.js
+++ b/client/src/redux/sagas/protx.sagas.js
@@ -4,7 +4,7 @@ import { fetchUtil } from '../../utils/fetchUtil';
 export function* fetchProtx(action) {
   yield put({ type: 'PROTX_INIT' });
   try {
-    const { maltreatment, demographics, texasBoundary, display } = yield all({
+    const { maltreatment, demographics, texasBoundary, display, resources } = yield all({
       maltreatment: call(fetchUtil, {
         url: `/api/protx/maltreatment`
       }),
@@ -16,6 +16,9 @@ export function* fetchProtx(action) {
       }),
       display: call(fetchUtil, {
         url: `/api/protx/display`
+      }),
+      resources: call(fetchUtil, {
+        url: `/api/protx/resources`
       })
     });
     yield put({
@@ -26,7 +29,8 @@ export function* fetchProtx(action) {
         maltreatment: maltreatment.data,
         maltreatmentMeta: maltreatment.meta,
         texasBoundary,
-        display
+        display,
+        resources
       }
     });
   } catch (error) {

--- a/client/src/redux/sagas/protx.sagas.js
+++ b/client/src/redux/sagas/protx.sagas.js
@@ -4,7 +4,13 @@ import { fetchUtil } from '../../utils/fetchUtil';
 export function* fetchProtx(action) {
   yield put({ type: 'PROTX_INIT' });
   try {
-    const { maltreatment, demographics, texasBoundary, display, resources } = yield all({
+    const {
+      maltreatment,
+      demographics,
+      texasBoundary,
+      display,
+      resources
+    } = yield all({
       maltreatment: call(fetchUtil, {
         url: `/api/protx/maltreatment`
       }),
@@ -30,7 +36,7 @@ export function* fetchProtx(action) {
         maltreatmentMeta: maltreatment.meta,
         texasBoundary,
         display,
-        resources
+        resources: resources.resources
       }
     });
   } catch (error) {

--- a/server/protx/data/api/urls.py
+++ b/server/protx/data/api/urls.py
@@ -7,5 +7,6 @@ urlpatterns = [
     url('display/', views.get_display, name='data'),
     url('maltreatment/', views.get_maltreatment, name='data'),
     url('demographics/', views.get_demographics, name='data'),
+    url('resources/', views.get_resources, name='data'),
     path('demographics-plot-distribution/<area>/<variable>/<unit>/', views.get_demographics_distribution_plot_data, name='data')
 ]

--- a/server/protx/data/api/views.py
+++ b/server/protx/data/api/views.py
@@ -51,6 +51,8 @@ GROUP BY
 '''
 
 SQLALCHEMY_DATABASE_URL = 'sqlite:////protx-data/cooks.db'
+SQLALCHEMY_RESOURCES_DATABASE_URL = 'sqlite:////protx-data/resources.db'
+
 MALTREATMENT_JSON_STRUCTURE_KEYS = ["GEOTYPE", "YEAR", "MALTREATMENT_NAME", "GEOID"]
 DEMOGRAPHICS_JSON_STRUCTURE_KEYS = ["GEOTYPE", "YEAR", "DEMOGRAPHICS_NAME", "GEOID"]
 
@@ -155,6 +157,7 @@ def get_demographics_distribution_plot_data(request, area, variable, unit):
     return JsonResponse({"result": result})
 
 
+# Require login depending on https://jira.tacc.utexas.edu/browse/COOKS-119
 def get_display(request):
     """Get display information data
     """
@@ -172,3 +175,16 @@ def get_display(request):
                 var[boolean_var_key] = True if (current_value == 1 or current_value == "1") else False
             result.append(var)
         return JsonResponse({"variables": result})
+
+
+# Require login depending on https://jira.tacc.utexas.edu/browse/COOKS-119
+def get_resources(request):
+    """Get display information data
+    """
+    engine = create_engine(SQLALCHEMY_RESOURCES_DATABASE_URL, connect_args={'check_same_thread': False})
+    with engine.connect() as connection:
+        resources = connection.execute("SELECT * FROM business_locations")
+        result = []
+        for r in resources:
+            result.append(dict(r))
+    return JsonResponse({"resources": result})


### PR DESCRIPTION
## Overview: ##

Initial work for COOKS-155 which adds:

* resources data endpoint to backend 
* initial markers of resources on map

## Related Jira tickets: ##

* [COOKS-15](https://jira.tacc.utexas.edu/browse/COOKS-155) <- initial work and doesn't close ticket.

## Summary of Changes: ##
* added backend routes for resources
* added initial frontend display of resources

## Testing Steps: ##
1. Locally, get example resources database and copy to `~/protx-data/resources.db`
2. View https://cep.dev/protx/demographics

## UI Photos:

![Screen Shot 2021-11-15 at 10 19 09 PM](https://user-images.githubusercontent.com/8287580/141914581-7c419049-4ef4-4711-83b9-ca9bf7926987.png)
## Notes: ##
TODO
- [ ] we should probably only show resources starting a certain zoom level. (can be done in this PR or somewher else

