### PR TITLE
Task/cooks 156 zoom to county to show resources

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12972,6 +12972,14 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
       "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw=="
     },
+    "leaflet-easybutton": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/leaflet-easybutton/-/leaflet-easybutton-2.4.0.tgz",
+      "integrity": "sha512-O+qsQq4zTF6ds8VClnytobTH/MKalctlPpiA8L+bNKHP14J3lgJpvEd/jSpq9mHTI6qOzRAvbQX6wS6qNwThvg==",
+      "requires": {
+        "leaflet": "^1.0.1"
+      }
+    },
     "leaflet.markercluster": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
     "jquery": "^3.6.0",
     "js-cookie": "^2.2.1",
     "leaflet": "^1.7.1",
+    "leaflet-easybutton": "^2.4.0",
     "leaflet.markercluster": "^1.5.3",
     "leaflet.vectorgrid": "^1.3.0",
     "lodash": "^4.17.21",

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -261,6 +261,11 @@ function MainMap({
             clickedGeographicFeature,
             highlightedStyle
           );
+          if (geography === 'county') {
+            // Simple zoom to point clicked and having fixed zoom level for counties
+            // See https://jira.tacc.utexas.edu/browse/COOKS-54
+            map.setView(e.latlng, 9);
+          }
         } else {
           updateSelectedGeographicFeature('');
         }

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -26,6 +26,8 @@ import IntervalColorScale from '../shared/colorsUtils';
 
 let mapContainer;
 
+const RESOURCE_ZOOM_LEVEL = 8; // resources will be displayed at this zoom level or higher
+
 const DefaultIcon = L.icon({
   iconUrl: icon,
   shadowUrl: iconShadow
@@ -213,6 +215,7 @@ function MainMap({
       if (refResourceLayers.current) {
         refResourceLayers.current.forEach(resourceLayer => {
           map.removeLayer(resourceLayer.layer);
+          layersControl.removeLayer(resourceLayer.layer);
         });
       }
 
@@ -220,7 +223,6 @@ function MainMap({
       const currentZoom = map.getZoom();
       Object.keys(resourcesClusterGroups).forEach(naicsCode => {
         const markersClusterGroup = resourcesClusterGroups[naicsCode];
-        map.addLayer(markersClusterGroup);
         const matchingMeta = resourcesMeta.find(
           r => r.NAICS_CODE === parseInt(naicsCode, 10)
         );
@@ -228,6 +230,10 @@ function MainMap({
           ? matchingMeta.DESCRIPTION
           : `Unknown Resource (${naicsCode})`;
         layersControl.addOverlay(markersClusterGroup, layerLabel);
+        if (currentZoom > RESOURCE_ZOOM_LEVEL) {
+          // we would only want to add to map (i.e. selection is ON) if zoomed in
+          map.addLayer(markersClusterGroup);
+        }
         newResourceLayers.push({
           label: layerLabel,
           layer: markersClusterGroup

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -3,6 +3,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import L from 'leaflet';
 import 'leaflet.vectorgrid';
 import 'leaflet.markercluster';
+import 'leaflet-easybutton';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import icon from 'leaflet/dist/images/marker-icon.png';
@@ -81,6 +82,10 @@ function MainMap({
       maxBoundsViscosity: 1.0,
       doubleClickZoom: false
     }).fitBounds(texasBounds);
+
+    L.easyButton('icon icon-globe', (btn, currentMap) => {
+      currentMap.fitBounds(texasBounds);
+    }).addTo(newMap);
 
     const texasOutline = L.vectorGrid
       .slicer(data.texasBoundary, {

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -113,7 +113,7 @@ function MainMap({
 
     // Create Layers Control.
     const { providers, layers: baseMaps } = MapProviders();
-    providers[3].addTo(newMap);
+    providers[0].addTo(newMap);
     const layerControl = L.control.layers(baseMaps).addTo(newMap);
     setLayersControl(layerControl);
     setMap(newMap);

--- a/client/src/components/ProTx/components/maps/MapProviders.js
+++ b/client/src/components/ProTx/components/maps/MapProviders.js
@@ -6,6 +6,7 @@ export default function Maptiles() {
 
   // Provider: Stamen.
   // No key required.
+  // eslint-disable-next-line no-unused-vars
   const basemapToner = L.tileLayer(
     'https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}{r}.{ext}',
     {
@@ -32,6 +33,7 @@ export default function Maptiles() {
     }
   );
 
+  // eslint-disable-next-line no-unused-vars
   const basemapTerrain = L.tileLayer(
     'https://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}{r}.{ext}',
     {
@@ -47,6 +49,7 @@ export default function Maptiles() {
 
   // Provider: Open Street Maps
   // No key required.
+  // eslint-disable-next-line no-unused-vars
   const basemapOsmDefault = L.tileLayer(
     'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
     {
@@ -59,6 +62,7 @@ export default function Maptiles() {
     }
   );
 
+  // eslint-disable-next-line no-unused-vars
   const basemapOsmTopo = L.tileLayer(
     'https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
     {
@@ -71,6 +75,7 @@ export default function Maptiles() {
     }
   );
 
+  // eslint-disable-next-line no-unused-vars
   const basemapOsmMapnik = L.tileLayer(
     'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
     {
@@ -95,13 +100,8 @@ export default function Maptiles() {
     }
   );
 
-  providers.push(basemapOsmDefault);
-  providers.push(basemapOsmTopo);
-  providers.push(basemapOsmMapnik);
   providers.push(basemapOsmBw);
-  providers.push(basemapToner);
   providers.push(basemapTonerLite);
-  providers.push(basemapTerrain);
 
   Object.keys(providers).forEach(k => {
     const layer = providers[k];


### PR DESCRIPTION
## Overview: ##

Show resources after zooming in to county.

## Related Jira tickets: ##

* [COOKS-155](https://jira.tacc.utexas.edu/browse/COOKS-155)
* [COOKS-156](https://jira.tacc.utexas.edu/browse/COOKS-156)

## Summary of Changes: ##

## Testing Steps: ##
1. New npm package so make sure to run `npm ci`
2. Go to map and click on county to zoom in
3. Click on globe to zoom back out
4. See that resource points are shown when zoomed in and that layers panel is expanded

## UI Photos:

![Screen Shot 2021-11-28 at 9 48 59 PM](https://user-images.githubusercontent.com/8287580/143899665-a754e7e4-9027-41b5-90dc-5207ed709a09.png)
![Screen Shot 2021-11-28 at 9 48 48 PM](https://user-images.githubusercontent.com/8287580/143899667-da4900e4-20a4-4029-8c30-fe8af444413f.png)
## Notes: ##
