### PR TITLE
add kurtosis and adaptive bin sizing to demographic_data_prep workflow

### DIFF
--- a/server/protx/data/api/demographics.py
+++ b/server/protx/data/api/demographics.py
@@ -37,7 +37,7 @@ def pearson_kurtosis(x):
     deviation = x - mean
     ratio = deviation / sigma
     k_vector = ratio ** 4
-    k = sum(k_vector)
+    k = np.mean(k_vector)
 
     return k
 

--- a/server/protx/data/api/demographics.py
+++ b/server/protx/data/api/demographics.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import numpy as np
 import sqlite3
-from scipy.stats import kurtosis
 
 
 # Aesthetics for plots
@@ -31,6 +30,18 @@ def hist_to_bar(vector, range_vals, bins):
     return height, edges
 
 
+def pearson_kurtosis(x):
+
+    sigma = np.std(x)
+    mean = np.mean(x)
+    deviation = x - mean
+    ratio = deviation / sigma
+    k_vector = ratio ** 4
+    k = sum(k_vector)
+
+    return k
+
+
 def get_bin_edges(query_return_df, label_template):
     all_data = query_return_df['VALUE'].values
     all_data = all_data[np.logical_not(np.isnan(all_data))]
@@ -51,7 +62,7 @@ def get_bin_edges(query_return_df, label_template):
     bar_centers = [round(((bin_edges[i - 1] + bin_edges[i]) / 2.0), 2) for i in range(1, len(bin_edges))]
 
     # measure kurtosis to determine binning strategy
-    k = kurtosis(all_data)
+    k = pearson_kurtosis(all_data)
 
     # k = 0 is close to a normal distribution; some of our data have k = 80
     if k < 10:
@@ -198,8 +209,8 @@ def demographic_data_prep(query_return_df):
     # set up response dictionary
     data_response = {
         'fig_aes': {
-            'hist_yrange': (hist_min, hist_max),
-            'yrange': range_vals,
+            'yrange': (hist_min, hist_max),
+            'simple_yrange': range_vals,
             'xrange': (0, 0),  # for horizontal boxplots, updated dynamically
             'geotype': query_return_df['GEOTYPE'].unique().item(),
             'label_units': label_units,


### PR DESCRIPTION
## Overview: ##

Additions to `demographics.py` to support server-side queries for ProTX portal data. Changes enable generation of "simple" demographics line charts and enable generation of easier-to-interpret "detailed" demographics histograms. **These changes may break the current "detailed" demographics charts.**

## Related Jira tickets: ##

* [COOKS-152](https://github.com/TACC/protx/tree/COOKS-152)

## Summary of Changes: ##

1. Implements `pearson_kurtosis` method to calculate distribution skew
2. Rewrote method `hist_to_bar` to return more simplified data
3. Added method `get_bin_edges` to (a) detect skewed distributions and (b) implement special binning for skewed distributions
4. Updated return data structure in `demographic_data_prep` to properly return y-axis range for histograms.
5. Adds element ['fig_aes']['center'] to `data_response` variable in `demographic_data_prep` to support variable-dependent display of measure of center in "simple" demographics chart

## Testing Steps: ##

1. Smoke test with import into notebook workflow at https://github.com/TACC/protx-db/blob/main/notebooks/Simple_and_Detailed_Demo.ipynb

## UI Photos:

N/A

## Notes: ##

Notebook https://github.com/TACC/protx-db/blob/main/notebooks/Simple_and_Detailed_Demo.ipynb shows the graphs and stylings intended to be generated from the output of `demographic_data_prep`
