### PR TITLE
Use protx-geospatial container for vector tiles

### DIFF
--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -78,7 +78,7 @@ services:
       - ../nginx/certificates/cep.dev.key:/etc/ssl/cep.dev.key
       - ../nginx/dhparam.pem:/etc/ssl/dhparam.pem
       - ../../../.:/srv/www/portal
-      - ~/protx-data:/protx-data
+      - protx_geospatial_data:/protx-data/static
     ports:
       - 80:80
       - 443:443
@@ -138,9 +138,19 @@ services:
     command: ['mkdocs', 'build']
     container_name: frontera_docs
 
+  protx_geospatial:
+    image: taccwma/protx-geospatial:latest
+    volumes:
+      - type: volume
+        source: protx_geospatial_data
+        target: /data
+    command: ['echo', 'Container provides data to volume and then exits']
+    container_name: protx_geospatial
+
 volumes:
   core_portal_redis_data:
   core_portal_es_data:
   core_portal_rabbitmq_data:
   core_portal_postgres_data:
   core_cms_postgres_data:
+  protx_geospatial_data:


### PR DESCRIPTION
## Overview: ##

I created a container for the generated vector tiles (see this repo https://github.com/TACC/protx-geospatial-data). 

Previously, John and I have been tar-ing them up and moving them around which is no fun.

## Related Jira tickets: ##

* [FP-197](https://jira.tacc.utexas.edu/browse/COOKS-197)

## Summary of Changes: ##

## Testing Steps: ##
1. Check that map loads with vectors tiles.

## Notes: ##

We should update our two deployments to use these containers as well. (ticket -> https://jira.tacc.utexas.edu/browse/COOKS-198)