### PR TITLE
Add simple cached results for some responses

### DIFF
--- a/server/poetry.lock
+++ b/server/poetry.lock
@@ -418,6 +418,14 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
 
 [[package]]
+name = "diskcache"
+version = "5.3.0"
+description = "Disk Cache -- Disk and file backed persistent cache."
+category = "main"
+optional = false
+python-versions = ">=3"
+
+[[package]]
 name = "django"
 version = "2.2.17"
 description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
@@ -1662,7 +1670,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<4.0"
-content-hash = "ee39a34a3922c32a24c4decdcd1423acc6a639784ba982ef238b9c50fad4282f"
+content-hash = "6ccfbfadbc7cd8d3ad15ce3e887161809265099f5b14952084586686851ffca7"
 
 [metadata.files]
 agavepy = [
@@ -1876,6 +1884,10 @@ daphne = [
 decorator = [
     {file = "decorator-4.4.2-py2.py3-none-any.whl", hash = "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"},
     {file = "decorator-4.4.2.tar.gz", hash = "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"},
+]
+diskcache = [
+    {file = "diskcache-5.3.0-py3-none-any.whl", hash = "sha256:75138cacec6c1d7b8339cc78912dd218d955f0706123e447a322a7ea4c97f270"},
+    {file = "diskcache-5.3.0.tar.gz", hash = "sha256:3f1fa30b29fdff26cfddcb3ee7d61376903f82c769ea2907a2b82a5bfb8abbe2"},
 ]
 django = [
     {file = "Django-2.2.17-py3-none-any.whl", hash = "sha256:558cb27930defd9a6042133258caf797b2d1dee233959f537e3dc475cb49bd7c"},

--- a/server/protx/data/api/decorators.py
+++ b/server/protx/data/api/decorators.py
@@ -1,5 +1,12 @@
 from functools import wraps
 from django.core.exceptions import PermissionDenied
+from diskcache import Cache
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+cache = Cache("database_cache")
 
 
 def onboarded_required(function):
@@ -15,3 +22,49 @@ def onboarded_required(function):
             raise PermissionDenied
 
     return wrapper
+
+
+def check_db_timestamp_and_cache_validity(db_file):
+    """ Check if cache should be updated as data db file has been modified
+
+        :param str db_file: path to file where results are derived.
+    """
+    def decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            current_data_db_timestamp = os.path.getmtime(db_file)
+            cached_data_db_timestamp = cache.get(db_file)
+            logger.debug("Getting cache results for {}: current file's modified time {}"
+                         " vs cached modified time {}.".format(db_file,
+                                                               current_data_db_timestamp,
+                                                               cached_data_db_timestamp))
+            if cached_data_db_timestamp != current_data_db_timestamp:
+                logger.info("Removing cache related to file '{}' as it has been updated.".format(db_file))
+                cache.clear()
+                cache.set(db_file, current_data_db_timestamp)
+            return f(*args, **kwargs)
+        return wrapper
+    return decorator
+
+
+def memoize_db_results(db_file):
+    """Provided cached results derived from a rarely changing db file
+
+    This decorator uses diskcache (`cache.memoize decorator`) to cache different
+    responses based upon the function+arguments.
+
+    If our data db file has been updated (i.e different timestamp), we should
+    invalidate that cache.
+
+    :param str db_file: path to file where results are derived.
+
+    """
+
+    def decorator(f):
+        @check_db_timestamp_and_cache_validity(db_file)
+        @cache.memoize()
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            return f(*args, **kwargs)
+        return wrapper
+    return decorator

--- a/server/protx/data/api/demographics.py
+++ b/server/protx/data/api/demographics.py
@@ -5,7 +5,8 @@ import pandas as pd
 from plotly.subplots import make_subplots
 from protx.data.api.utils.plotly_figures import timeseries_lineplot
 
-# Aesthetics for plots
+db_name = '/protx-data/cooks.db'
+
 
 def currency(value1, value2):
     return '{:.0f}-{:.0f}'.format(round(value1 / 1000, 0), round(value2 / 1000, 0))
@@ -297,7 +298,6 @@ def update_focal_area(display_dict, focal_data):
 
 
 def demographic_data_query(area, unit, variable):
-    db_name = '/protx-data/cooks.db'
     db_conn = sqlite3.connect(db_name)
     selection = {'area': area, 'unit': unit, 'variable': variable, 'report_type': 'demographics'}
     query = yearly_data_query.format(**selection)
@@ -307,7 +307,6 @@ def demographic_data_query(area, unit, variable):
 
 
 def demographic_focal_area_data_query(area, geoid, unit, variable):
-    db_name = '/protx-data/cooks.db'
     db_conn = sqlite3.connect(db_name)
     selection = {'area': area, 'geoid': geoid, 'unit': unit, 'variable': variable, 'report_type': 'demographics'}
     query = focal_query.format(**selection)

--- a/server/protx/data/api/demographics.py
+++ b/server/protx/data/api/demographics.py
@@ -2,7 +2,6 @@ import sqlite3
 import json
 import numpy as np
 import pandas as pd
-from plotly.subplots import make_subplots
 from protx.data.api.utils.plotly_figures import timeseries_lineplot
 
 db_name = '/protx-data/cooks.db'
@@ -333,8 +332,3 @@ def demographics_simple_lineplot_figure(area, geoid, unit, variable):
     # Generate the plot figure data object.
     plot_figure = timeseries_lineplot(plot_result)
     return json.loads(plot_figure.to_json())
-
-
-if None:
-    result = demographic_histogram_data(area='county', unit='count', variable='DISABL')
-    print(result)

--- a/server/protx/data/api/views.py
+++ b/server/protx/data/api/views.py
@@ -4,12 +4,9 @@ from sqlalchemy import create_engine
 import logging
 
 from protx.data.api import demographics
-from protx.data.api.decorators import onboarded_required
+from protx.data.api.decorators import onboarded_required, memoize_db_results
 from portal.exceptions.api import ApiException
 
-from diskcache import Cache
-
-cache = Cache("database_cache")
 
 logger = logging.getLogger(__name__)
 
@@ -54,8 +51,10 @@ GROUP BY
     d.DEMOGRAPHICS_NAME;
 '''
 
-SQLALCHEMY_DATABASE_URL = 'sqlite:////protx-data/cooks.db'
-SQLALCHEMY_RESOURCES_DATABASE_URL = 'sqlite:////protx-data/resources.db'
+resources_db = '/protx-data/resources.db'
+
+SQLALCHEMY_DATABASE_URL = 'sqlite:///{}'.format(demographics.db_name)
+SQLALCHEMY_RESOURCES_DATABASE_URL = 'sqlite:///{}'.format(resources_db)
 
 MALTREATMENT_JSON_STRUCTURE_KEYS = ["GEOTYPE", "YEAR", "MALTREATMENT_NAME", "GEOID"]
 DEMOGRAPHICS_JSON_STRUCTURE_KEYS = ["GEOTYPE", "YEAR", "DEMOGRAPHICS_NAME", "GEOID"]
@@ -122,7 +121,7 @@ def get_maltreatment(request):
     return get_maltreatment_cached()
 
 
-@cache.memoize()
+@memoize_db_results(db_file=demographics.db_name)
 def get_maltreatment_cached():
     """Get maltreatment data
 
@@ -144,7 +143,7 @@ def get_demographics(request):
     return get_demographics_cached()
 
 
-@cache.memoize()
+@memoize_db_results(db_file=demographics.db_name)
 def get_demographics_cached():
     """Get demographics data
 
@@ -198,7 +197,7 @@ def get_resources(request):
     return get_resources_cached()
 
 
-@cache.memoize()
+@memoize_db_results(db_file=resources_db)
 def get_resources_cached():
     engine = create_engine(SQLALCHEMY_RESOURCES_DATABASE_URL, connect_args={'check_same_thread': False})
     with engine.connect() as connection:

--- a/server/protx/data/api/views.py
+++ b/server/protx/data/api/views.py
@@ -7,6 +7,9 @@ from protx.data.api import demographics
 from protx.data.api.decorators import onboarded_required
 from portal.exceptions.api import ApiException
 
+from diskcache import Cache
+
+cache = Cache("database_cache")
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +119,11 @@ def create_dict(data, level_keys):
 @onboarded_required
 @ensure_csrf_cookie
 def get_maltreatment(request):
+    return get_maltreatment_cached()
+
+
+@cache.memoize()
+def get_maltreatment_cached():
     """Get maltreatment data
 
     """
@@ -133,7 +141,12 @@ def get_maltreatment(request):
 @onboarded_required
 @ensure_csrf_cookie
 def get_demographics(request):
-    """Get maltreatment data
+    return get_demographics_cached()
+
+
+@cache.memoize()
+def get_demographics_cached():
+    """Get demographics data
 
     """
     engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={'check_same_thread': False})
@@ -182,6 +195,11 @@ def get_display(request):
 def get_resources(request):
     """Get display information data
     """
+    return get_resources_cached()
+
+
+@cache.memoize()
+def get_resources_cached():
     engine = create_engine(SQLALCHEMY_RESOURCES_DATABASE_URL, connect_args={'check_same_thread': False})
     with engine.connect() as connection:
         resources = connection.execute("SELECT * FROM business_locations")

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -45,6 +45,7 @@ python-magic = "^0.4.18"
 SQLAlchemy = "^1.4.24"
 pandas = "^1.3.3"
 plotly = "^5.5.0"
+diskcache = "^5.3.0"
 
 [tool.poetry.dev-dependencies]
 mock = "^4.0.2"


### PR DESCRIPTION
## Overview: ##

Add simple caching mechanism to speed up responses

## Related Jira tickets: ##

* [COOKS-199](https://jira.tacc.utexas.edu/browse/COOKS-199)

## Summary of Changes: ##

## Testing Steps: ##
1.  Go to /protx/maltreatment or /protx/demographics and notice time to load (>20 or 30 secs?)
2. Subsequent reloads of that page should now be much quicker
3. Invalidate cache by changing timestamp of dbs: `touch ~/protx-data/cooks.db ~/protx-data/resources.db`
4. Reload app and notice that it takes a long time again

## Notes: ##
TODO
- [x] add check to compare db timestamp to clear cache.
