### PR TITLE
Bug/COOKS-181: Fix feature deselection style on zoom out.

### DIFF
--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -55,7 +55,6 @@ function MainMap({
   // Leaflet related layers, controls, and map
   const [legendControl, setLegendControl] = useState(null);
   const [layersControl, setLayersControl] = useState(null);
-  const [dataLayer, setDataLayer] = useState(null);
   const [resourceLayers, setResourceLayers] = useState(null);
   const [texasOutlineLayer, setTexasOutlineLayer] = useState(null);
   const [map, setMap] = useState(null);
@@ -66,6 +65,7 @@ function MainMap({
   const refSelectedGeoid = useRef(selectedGeoid); // Make a ref of the selected feature
   const refResourceLayers = useRef(resourceLayers); // Make a ref of the resources layers
   const refZoomLevel = useRef(zoomLevel); // Make a ref of the resources layers
+  const refDataLayer = useRef(null); // Make a ref of the data layer
 
   function updateSelectedGeographicFeature(newSelectedFeature) {
     refSelectedGeoid.current = newSelectedFeature;
@@ -88,8 +88,7 @@ function MainMap({
   const handleZoom = (
     newZoomLevel,
     currentMap,
-    currentLayerControl,
-    currentDataLayer
+    currentLayerControl
   ) => {
     const previousZoomLevel = refZoomLevel.current;
     const zoomTransitionOccurred =
@@ -113,7 +112,7 @@ function MainMap({
           // deselecting here as well as in click handler; deselecting here
           // is covering the scenario when we are zooming out
           /// https://jira.tacc.utexas.edu/browse/COOKS-181
-          currentDataLayer.resetFeatureStyle(refSelectedGeoid.current);
+          refDataLayer.current.resetFeatureStyle(refSelectedGeoid.current);
         }
         updateSelectedGeographicFeature('');
       }
@@ -172,13 +171,13 @@ function MainMap({
     }, 0);
   }, [data, mapContainer]);
   useEffect(() => {
-    if (map && layersControl && dataLayer) {
+    if (map && layersControl && refDataLayer.current) {
       map.on('zoomend', () => {
         const currentZoom = map.getZoom();
-        handleZoom(currentZoom, map, layersControl, dataLayer);
+        handleZoom(currentZoom, map, layersControl);
       });
     }
-  }, [map, layersControl, dataLayer]);
+  }, [map, layersControl, refDataLayer.current]);
 
   useEffect(() => {
     if (map) {
@@ -348,9 +347,9 @@ function MainMap({
         maxNativeZoom: 14 // All tiles generated up to 14 zoom level
       });
 
-      if (dataLayer && layersControl) {
+      if (refDataLayer.current && layersControl) {
         // we will remove data layer from map
-        dataLayer.remove();
+        refDataLayer.current.remove();
       }
 
       // Add click handler
@@ -359,7 +358,7 @@ function MainMap({
           e.layer.properties[GEOID_KEY[geography]];
 
         if (refSelectedGeoid.current) {
-          newDataLayer.resetFeatureStyle(refSelectedGeoid.current);
+          refDataLayer.current.resetFeatureStyle(refSelectedGeoid.current);
         }
 
         if (clickedGeographicFeature !== refSelectedGeoid.current) {
@@ -395,7 +394,6 @@ function MainMap({
 
       // add new data layer to map
       newDataLayer.addTo(map);
-      setDataLayer(newDataLayer);
 
       // updated/new layer
       if (selectedGeographicFeature) {
@@ -419,6 +417,8 @@ function MainMap({
           highlightedStyle
         );
       }
+
+      refDataLayer.current = newDataLayer;
 
       // ensure that texas outline is on top
       texasOutlineLayer.bringToFront();


### PR DESCRIPTION
## Overview: ##
Reset selected feature style on zooming out.

## Related Jira tickets: ##

* [COOKS-181](https://jira.tacc.utexas.edu/browse/COOKS-181)

## Summary of Changes: ##
The `dataLayer` state seemed to not work with the set layer (`newDataLayer`).
Not just with `resetFeatureStyle` but also with `setFeatureStyle`.
I think something funky goes on with the shallow copy on the state hook and it's referring to the wrong object pointer.
So, I tried setting the layer with a ref hook. And it worked 😃

## Testing Steps: ##
1. Select a map feature so that it zooms and creates a border.
2. Click the globe to zoom out.
3. Ensure that the style is reset.

## UI Photos:

## Notes: ##
