### PR TITLE
Bug/COOKS-153: County selection incorrect display color

### DIFF
--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -373,7 +373,8 @@ function MainMap({
               year,
               clickedGeographicFeature,
               observedFeature,
-              maltreatmentTypes
+              maltreatmentTypes,
+              showRate
             ),
             color: 'black',
             weight: 2.0,
@@ -408,7 +409,8 @@ function MainMap({
             year,
             selectedGeographicFeature,
             observedFeature,
-            maltreatmentTypes
+            maltreatmentTypes,
+            showRate
           ),
           color: 'black',
           weight: 2.0,


### PR DESCRIPTION
## Overview: ##
Fixes bug where county selection is always displayed as an incorrect color.

## Related Jira tickets: ##

* [COOKS-153](https://jira.tacc.utexas.edu/browse/COOKS-153)

## Summary of Changes: ##
The `showRate` value was missing in the `getFeatureStyle` call when click-selecting county features. Thus, it gave the incorrect `featureValue`, 1. 

## Testing Steps: ##
1. Select a county.
2. Ensure that the color is correct and only the border is drawn.

## UI Photos:
N/A

## Notes: ##
