### PR TITLE
Pin CMS image Tag, set default unit types for charts Maltreatment, Demographics

### DIFF
--- a/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
+++ b/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
@@ -48,7 +48,7 @@ function DashboardDisplay() {
     if (mapType === 'maltreatment') {
       // maltreatment only has county data.
       setGeography('county');
-      setUnit('count');
+      setUnit('rate_per_100k_under17');
     } else {
       // observedFeatures (i.e. Demographic Features) and analytics
       setYear('2019'); // observedFeatures (i.e. Demographic Features) only has 2019 data.

--- a/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
+++ b/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
@@ -48,12 +48,12 @@ function DashboardDisplay() {
     if (mapType === 'maltreatment') {
       // maltreatment only has county data.
       setGeography('county');
-      setUnit('percent');
+      setUnit('count');
     } else {
       // observedFeatures (i.e. Demographic Features) and analytics
       setYear('2019'); // observedFeatures (i.e. Demographic Features) only has 2019 data.
       setGeography('county');
-      setUnit('count');
+      setUnit('percent');
     }
   }, [mapType]);
 

--- a/server/conf/docker/docker-compose-dev.all.debug.yml
+++ b/server/conf/docker/docker-compose-dev.all.debug.yml
@@ -4,7 +4,7 @@
 version: '3.8'
 services:
   cms:
-    image: taccwma/protx-cms:latest
+    image: taccwma/protx-cms:5a09f44
     volumes:
       - ../cms/secrets.py:/code/taccsite_cms/secrets.py
       - ../cms/uwsgi/uwsgi.ini:/code/uwsgi.ini


### PR DESCRIPTION
Pinned the cms container image tag in docker-compose.all until we unfork from upstream, otherwise we will encounter build errors. 

Switched the default unit value for the charts so that Percents are used on Demographics and count is used on Maltreatment. 

## Overview: ##

## Related Jira tickets: ##

* [COOKS-238](https://jira.tacc.utexas.edu/browse/COOKS-238)
* [COOKS-240](https://jira.tacc.utexas.edu/browse/COOKS-240)

## Summary of Changes: ##

- Pinned image tag.
- Switched default unit to use in charts.

## Testing Steps: ##

1. Build and run project.

## UI Photos:

## Notes: ##

I am encountering an inconsistent rendering issue with the DisplaySelector labelRadioBtn1 not being actively selected in the UI by default, even though the component state is correct and renders the plot using the  correct unit on map selection.