### PR TITLE
COOKS-229: White Dropdown Bkgd for Maltreat. App

### DIFF
--- a/client/src/components/ProTx/components/dashboard/MaltreatmentSelector.css
+++ b/client/src/components/ProTx/components/dashboard/MaltreatmentSelector.css
@@ -12,17 +12,9 @@
 .rmsc .dropdown-container .dropdown-content {
   z-index: 9999;
 }
-.rmsc .dropdown-content .panel-content {
-  --rmsc-bgdd: var(--global-color-primary--dark) !important;
-  color: var(--color-white) !important;
-}
 .rmsc .dropdown-container .dropdown-content .panel-content {
   border-bottom-left-radius: 6px;
   border-bottom-right-radius: 6px;
-}
-.rmsc .dropdown-container .dropdown-content * {
-  color: var(--color-white);
-  background: var(--color-gray-very-dark);
 }
 .dropdown-heading-value {
   color: var(--global-color-accent--normal);
@@ -30,9 +22,6 @@
 .rmsc .dropdown-content .panel-content .select-item {
   height: var(--selector-constant-height);
 }
-/* This will hide the weird highlighting in the component. */
-.rmsc .dropdown-content .panel-content .select-item,
-.rmsc .dropdown-content .panel-content .select-item .label,
-.rmsc .dropdown-content .panel-content *:hover {
-  background-color: var(--color-gray-very-dark) !important;
+.rmsc .dropdown-content .panel-content .select-item {
+  background-color: unset;
 }


### PR DESCRIPTION
## Overview: ##

Change 3rd-party dropdown to white background (dark text).

## Related Jira tickets: ##

* [COOKS-229](https://jira.tacc.utexas.edu/browse/COOKS-229)

## Summary of Changes: ##

1. Remove all black/white/gray background and text color styles.
2. Unset one background color.

## Testing Steps: ##

⚠️ I tested against staging (pre-prod) code.

1. Open Maltreatment page.
2. Open dropdown.
3. See white background.
4. Interact (hover, select, clear, deselect, choose).
5. Confirm no weirdness related to code change.

## UI Photos: ##

![COOKS-229](https://user-images.githubusercontent.com/62723358/163293574-6c2dea44-75ae-4caf-aaf3-158d075fcc82.png)

## Notes: ##

I didn't do anything else because ticket focuses on background and I am under the impression ProTX is in rush hour right now, so I git-r-done.