### PR TITLE
Legend linebreaks

### DIFF
--- a/client/src/components/ProTx/components/charts/AnalyticsDetails.js
+++ b/client/src/components/ProTx/components/charts/AnalyticsDetails.js
@@ -44,7 +44,7 @@ function AnalyticsDetails({
         </div>
       </div>
       <div className="plot-details-summary">
-        All graphs are showing data for calendar years 2011-2019, not fiscal or
+        All graphs are showing data for calendar years 2011-2020, not fiscal or
         academic years.
       </div>
     </>

--- a/client/src/components/ProTx/components/charts/DemographicsDetails.js
+++ b/client/src/components/ProTx/components/charts/DemographicsDetails.js
@@ -44,7 +44,7 @@ function DemographicsDetails({
         </div>
       </div>
       <div className="plot-details-summary">
-        All graphs are showing data for calendar years 2011-2019, not fiscal or
+        All graphs are showing data for calendar years 2011-2020, not fiscal or
         academic years.
       </div>
     </>

--- a/client/src/components/ProTx/components/charts/MaltreatmentDetails.js
+++ b/client/src/components/ProTx/components/charts/MaltreatmentDetails.js
@@ -50,7 +50,7 @@ function MaltreatmentDetails({
         </div>
       </div>
       <div className="plot-details-summary">
-        All graphs are showing data for calendar years 2011-2019, not fiscal or
+        All graphs are showing data for calendar years 2011-2020, not fiscal or
         academic years.
       </div>
     </>

--- a/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
+++ b/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
@@ -13,7 +13,6 @@ function DashboardDisplay() {
   // TODO: control of this state (county, year, feature etc) should be moved to redux/sagas (https://jira.tacc.utexas.edu/browse/COOKS-55)
   const [mapType, setMapType] = useState('maltreatment');
   const [geography, setGeography] = useState('county');
-  const defaultYear = '2020';
   const PRESELECTED_MALTREATMENT_CATEGORIES = [
     'ABAN',
     'EMAB',
@@ -26,11 +25,12 @@ function DashboardDisplay() {
     'SXAB',
     'SXTR'
   ];
+  const DEFAULT_YEAR = '2020';
   const [maltreatmentTypes, setMaltreatmentTypes] = useState(
     PRESELECTED_MALTREATMENT_CATEGORIES
   );
   const [observedFeature, setObservedFeature] = useState('AGE17');
-  const [year, setYear] = useState('2019');
+  const [year, setYear] = useState(DEFAULT_YEAR);
   const [selectedGeographicFeature, setSelectedGeographicFeature] = useState(
     ''
   );
@@ -51,8 +51,7 @@ function DashboardDisplay() {
       setGeography('county');
       setUnit('rate_per_100k_under17');
     } else {
-      // observedFeatures (i.e. Demographic Features) and analytics
-      setYear(defaultYear); // observedFeatures (i.e. Demographic Features) only has 2019 data.
+      setYear(DEFAULT_YEAR);
       setGeography('county');
       setUnit('percent');
     }
@@ -170,7 +169,7 @@ function DashboardDisplay() {
                       mapType={mapType}
                       geography={geography}
                       observedFeature={observedFeature}
-                      year={defaultYear}
+                      year={DEFAULT_YEAR}
                       selectedGeographicFeature={selectedGeographicFeature}
                       data={data}
                       unit={unit}

--- a/client/src/components/ProTx/components/dashboard/MaltreatmentSelector.css
+++ b/client/src/components/ProTx/components/dashboard/MaltreatmentSelector.css
@@ -12,17 +12,9 @@
 .rmsc .dropdown-container .dropdown-content {
   z-index: 9999;
 }
-.rmsc .dropdown-content .panel-content {
-  --rmsc-bgdd: var(--global-color-primary--dark) !important;
-  color: var(--color-white) !important;
-}
 .rmsc .dropdown-container .dropdown-content .panel-content {
   border-bottom-left-radius: 6px;
   border-bottom-right-radius: 6px;
-}
-.rmsc .dropdown-container .dropdown-content * {
-  color: var(--color-white);
-  background: var(--color-gray-very-dark);
 }
 .dropdown-heading-value {
   color: var(--global-color-accent--normal);
@@ -30,9 +22,6 @@
 .rmsc .dropdown-content .panel-content .select-item {
   height: var(--selector-constant-height);
 }
-/* This will hide the weird highlighting in the component. */
-.rmsc .dropdown-content .panel-content .select-item,
-.rmsc .dropdown-content .panel-content .select-item .label,
-.rmsc .dropdown-content .panel-content *:hover {
-  background-color: var(--color-gray-very-dark) !important;
+.rmsc .dropdown-content .panel-content .select-item {
+  background-color: unset;
 }

--- a/client/src/components/ProTx/components/shared/dataUtils.js
+++ b/client/src/components/ProTx/components/shared/dataUtils.js
@@ -125,6 +125,9 @@ const getMaltreatmentMetaData = (
     const values = Object.values(aggregrateValues).map(x => +x);
     if (values.length) {
       meta = { min: Math.min(...values), max: Math.max(...values) };
+    } else {
+      // no values were found
+      return null;
     }
   }
   if (meta.max < 100.0000001 && meta.min > 99.9999999) {

--- a/server/protx/data/api/demographics.py
+++ b/server/protx/data/api/demographics.py
@@ -87,8 +87,7 @@ def get_bin_edges(query_return_df, label_template):
         bar_centers_threshold = bar_centers[0: len(edges_threshold) + 1]
 
         # update the bar labels
-        label_fmt_threshold = [label_template(edges_threshold[i - 1], edges_threshold[i]) for i in
-                               range(1, len(edges_threshold))]
+        label_fmt_threshold = [label_template(edges_threshold[i - 1], edges_threshold[i]) for i in range(1, len(edges_threshold))]
 
         return edges_threshold, bar_centers_threshold, label_fmt_threshold
 

--- a/server/protx/data/api/demographics.py
+++ b/server/protx/data/api/demographics.py
@@ -2,8 +2,7 @@ import sqlite3
 import json
 import numpy as np
 import pandas as pd
-#from protx.data.api.utils.plotly_figures import timeseries_lineplot
-from .utils.plotly_figures import timeseries_lineplot
+from protx.data.api.utils.plotly_figures import timeseries_lineplot
 
 db_name = '/protx-data/cooks.db'
 

--- a/server/protx/data/api/demographics.py
+++ b/server/protx/data/api/demographics.py
@@ -2,8 +2,8 @@ import sqlite3
 import json
 import numpy as np
 import pandas as pd
-from protx.data.api.utils.plotly_figures import timeseries_lineplot
-
+#from protx.data.api.utils.plotly_figures import timeseries_lineplot
+from .utils.plotly_figures import timeseries_lineplot
 
 db_name = '/protx-data/cooks.db'
 
@@ -130,7 +130,8 @@ def get_bin_edges(query_return_df, label_template):
 
 yearly_data_query = '''
 select d.VALUE, d.GEOID, d.GEOTYPE, d.DEMOGRAPHICS_NAME, d.YEAR,
-    d.UNITS as count_or_pct, g.DISPLAY_TEXT as geo_display, u.UNITS as units, u.DISPLAY_TEXT as units_display
+    d.UNITS as count_or_pct, g.DISPLAY_TEXT as geo_display, u.UNITS as units,
+    u.DISPLAY_TEXT as units_display, u.DISPLAY_TEXT_PLOT as units_plot
 from {report_type} d
 left join display_geotype g on
     g.GEOID = d.GEOID and
@@ -147,7 +148,8 @@ where d.GEOTYPE = "{area}" and
 
 focal_query = '''
 select d.VALUE, d.GEOID, d.GEOTYPE, d.DEMOGRAPHICS_NAME, d.YEAR,
-    d.UNITS as count_or_pct, g.DISPLAY_TEXT as geo_display, u.UNITS as units, u.DISPLAY_TEXT as units_display
+    d.UNITS as count_or_pct, g.DISPLAY_TEXT as geo_display, u.UNITS as units, 
+    u.DISPLAY_TEXT as units_display, u.DISPLAY_TEXT_PLOT as units_plot
 from {report_type} d
 left join display_geotype g on
     g.GEOID = d.GEOID and
@@ -185,9 +187,11 @@ def demographic_data_prep(query_return_df):
         label_template = currency
         # division is done in formatting helper but could be pushed up to .db file
         label_units = query_return_df['units_display'].unique().item() + ' (1000s of dollars)'
+        label_legend = query_return_df['units_plot'].unique().item() + ' (1000s of dollars)'
     else:
         label_template = not_currency
         label_units = query_return_df['units_display'].unique().item()
+        label_legend = query_return_df['units_plot'].unique().item()
         # for line plots, PCI should use median and others should use mean
     if query_return_df['DEMOGRAPHICS_NAME'].unique().item() == 'PCI':
         center = 'median'
@@ -217,6 +221,7 @@ def demographic_data_prep(query_return_df):
             'xrange': (0, 0),  # for horizontal boxplots, updated dynamically
             'geotype': query_return_df['GEOTYPE'].unique().item(),
             'label_units': label_units,
+            'label_legend': label_legend,
             'bar_labels': None,
             'bar_centers': None,
             'focal_display': None,
@@ -226,14 +231,14 @@ def demographic_data_prep(query_return_df):
             i: {'focal_value': None,
                 'mean': None,
                 'median': None,
-                'bars': [None]} for i in range(2011, 2020)}
+                'bars': [None]} for i in range(2011, 2021)}
     }
 
     ################################
     # CALCULATE ANNUAL HISTOGRAMS ##
     ################################
 
-    for year in range(2010, 2020):
+    for year in range(2010, 2021):
         data = query_return_df[query_return_df['YEAR'] == year]['VALUE'].values
         data = data[np.logical_not(np.isnan(data))]
 
@@ -285,7 +290,7 @@ def update_focal_area(display_dict, focal_data):
 
     focal_dict = focal_data[['YEAR', 'VALUE']].set_index('YEAR').transpose().to_dict(orient='records')[0]
     display_dict['fig_aes']['focal_display'] = display_name
-    for year in range(2011, 2020):
+    for year in range(2011, 2021):
         try:
             focal_val = focal_dict[year]
         except KeyError:

--- a/server/protx/data/api/maltreatment.py
+++ b/server/protx/data/api/maltreatment.py
@@ -9,22 +9,18 @@ logger = logging.getLogger(__name__)
 
 db_name = '/protx-data/cooks.db'
 
-# ten-color qualitative palette from colorbrewer2
 maltrt_palette = {
-    'Abandonment': '#001E2E',
+    'Abandonment': '#001e2e',
     'Emotional abuse': '#003b5c',
-    'Labor trafficking': '#007396',
-    'Labor trafficing': '#41748d',
-    'Medical neglect': '#bbdde6',
-    'Neglectful supervision': '#69dbc8',
-    'Physical abuse': '#007a53',
-    'Physical neglect': '#a9c47f',
+    'Labor trafficking': '#545859',
+    'Medical neglect': '#007a53',
+    'Neglectful supervision': '#41748d',
+    'Physical abuse': '#a9c47f',
+    'Physical neglect': '#b9d3dc',
     'Refusal to accept parental responsibility': '#d4ec8e',
-    'Sexual abuse': '#EAF6C7',
-    'Sex trafficing': '#e9df97',
-    'Sex trafficking': '#898d8d'
+    'Sexual abuse': '#CCCC99',
+    'Sex trafficking': '#eaf6c7'
 }
-
 
 """ 
 TODO: Lookup the {focal_value} string value using the geoid value instead of passing the selectedArea string vaalue from the client. The {focal_value}is used as the DISPLAY_TEXT in the query.
@@ -32,7 +28,8 @@ TODO: Lookup the {focal_value} string value using the geoid value instead of pas
 
 maltrt_query = '''
 select d.VALUE, d.GEOID, d.GEOTYPE, d.MALTREATMENT_NAME, d.YEAR, d.UNITS as count_or_pct,
-    g.DISPLAY_TEXT as geo_display, u.UNITS as units, u.DISPLAY_TEXT as units_display
+    g.DISPLAY_TEXT as geo_display, u.UNITS as units, u.DISPLAY_TEXT as units_display,
+    u.DISPLAY_TEXT_PLOT as units_display_plot
 from maltreatment d
 left join display_geotype g on
     g.GEOID = d.GEOID and
@@ -42,17 +39,17 @@ join display_data u on
     d.MALTREATMENT_NAME = u.NAME
 where d.GEOTYPE = "{area}" and
     g.DISPLAY_TEXT = "{focal_area}" and
-    d.MALTREATMENT_NAME in ({variables}) and
+    d.MALTREATMENT_NAME in ({variable}) and
     d.units = "{units}";
 '''
 
 
 def query_return(user_selection, db_conn, palette=maltrt_palette):
-
     # don't show percents when user has selected all maltreatment types
     # todo: move this sanity check to elsewhere in processing?
-    # if user_selection['units'] == 'percent':
-    #     assert user_selection['variables'] == '"ABAN", "EMAB", "MDNG", "NSUP", "PHAB", "PHNG", "RAPR", "SXAB", "SXTR", "LBTR"'
+    if user_selection['units'] == 'percent':
+        assert user_selection[
+                   'variable'] == '"ABAN", "EMAB", "MDNG", "NSUP", "PHAB", "PHNG", "RAPR", "SXAB", "SXTR", "LBTR"'
 
     # query user input (return all units, regardless of user selection)
     # query template defined in global namespace
@@ -63,17 +60,17 @@ def query_return(user_selection, db_conn, palette=maltrt_palette):
     years = sorted(maltrt_data['YEAR'].unique())
 
     # extract maltrt types in dataset
-    mt = sorted(maltrt_data['units_display'].unique(), reverse=True)
+    mt_ = maltrt_data[['units_display', 'units_display_plot']].drop_duplicates().sort_values(['units_display'])
+    mt = [i for i in zip(mt_['units_display'], mt_['units_display_plot'])]  # iterable to list is necessary
 
     coords = [(i, j) for i in years for j in mt]
 
     maltrt_wide = maltrt_data.pivot_table(columns=['YEAR', 'units_display'], values='VALUE', aggfunc=sum)
 
-    return {'coords': coords, 'data': maltrt_wide, 'colors': palette}
+    return {'coords': coords, 'data': maltrt_wide, 'colors': palette, 'units': user_selection['units']}
 
 
-def maltrt_stacked_bar(maltrt_data_dict, unit_selected):
-
+def maltrt_stacked_bar(maltrt_data_dict):
     data_coords = maltrt_data_dict['coords']
     data = maltrt_data_dict['data']
     palette = maltrt_data_dict['colors']
@@ -81,30 +78,47 @@ def maltrt_stacked_bar(maltrt_data_dict, unit_selected):
     fig_data = []
     for c in data_coords:
         try:
-            maltrt_count = data[c]
+            multiindex = (c[0], c[1][0])  # year, non-formatted name
+            maltrt_count = data[multiindex]
         except KeyError:
             maltrt_count = [0]
 
         fig_data.append(
-            go.Bar(name=c[1], x=[str(c[0])], y=maltrt_count, marker_color=palette[c[1]])
+            go.Bar(
+                name=c[1][1],
+                x=[str(c[0])],
+                y=maltrt_count,
+                marker_color=palette[c[1][0]]
+            )
         )
 
     fig = go.Figure(data=fig_data)
     fig.update_layout(barmode='stack')
-
-    if unit_selected == 'count':
-        fig.update_yaxes(title_text="Aggregated Totals")
-    if unit_selected == 'percent':
-        fig.update_yaxes(title_text="Percent of Total")
-    if unit_selected == 'rate_per_100k_under17':
-        fig.update_yaxes(title_text="Rate per 100K")
+    if maltrt_data_dict['units'] == 'percent':
+        fig.update_yaxes(title_text="Percent of Total Incidents")
+    elif maltrt_data_dict['units'] == 'rate_per_100k_under17':
+        fig.update_yaxes(title_text="Incident Rate per 100k Children")
+    elif maltrt_data_dict['units'] == 'count':
+        fig.update_yaxes(title_text="Incident Count")
 
     # to deduplicate the legend, from https://stackoverflow.com/questions/26939121/how-to-avoid-duplicate-legend-labels-in-plotly-or-pass-custom-legend-labels
     names = set()
     fig.for_each_trace(
         lambda trace:
-            trace.update(showlegend=False)
-            if (trace.name in names) else names.add(trace.name))
+        trace.update(showlegend=False)
+        if (trace.name in names) else names.add(trace.name))
+
+    fig.update_layout(
+        yaxis=dict(
+            titlefont=dict(size=18),
+            tickfont=dict(size=16)
+        ),
+        legend=dict(
+            font=dict(size=16),
+            traceorder='normal'
+        ),
+        xaxis=dict(tickfont=dict(size=16))
+    )
 
     return fig
 

--- a/server/protx/data/api/maltreatment.py
+++ b/server/protx/data/api/maltreatment.py
@@ -45,17 +45,6 @@ where d.GEOTYPE = "{area}" and
 
 
 def query_return(user_selection, db_conn, palette=maltrt_palette):
-    # TODO: move this sanity check to elsewhere in processing?
-    if user_selection['units'] == 'percent':
-        try:
-            assert user_selection['variables'] == '"ABAN","EMAB","LBTR","MDNG","NSUP","PHAB","PHNG","RAPR","SXAB","SXTR"'
-        except:
-            print("Assertion error on percent Type selection. Auto-selecting all categories.")
-            user_selection['variables'] = '"ABAN","EMAB","LBTR","MDNG","NSUP","PHAB","PHNG","RAPR","SXAB","SXTR"'
-
-    # TODO: when Value is set to Percentages, auto-select all categories in the Type drop-down menu.
-    # TODO: After the selection is updated, make sure the Map properly reflect all categories selected.
-
     # query user input (return all units, regardless of user selection)
     # query template defined in global namespace
     maltrt_query_fmt = maltrt_query.format(**user_selection)

--- a/server/protx/data/api/utils/plotly_figures.py
+++ b/server/protx/data/api/utils/plotly_figures.py
@@ -6,7 +6,28 @@
   - https://github.com/TACC/protx-db/blob/main/notebooks/Simple_and_Detailed_Demo.ipynb
 """
 from plotly.subplots import make_subplots
+from plotly.colors import n_colors
 import plotly.graph_objects as go
+
+
+def wrap_text(text):
+    if len(text) > 25:
+        text_template = '{}{}{}'
+        split_disp = text.split(' ')
+        new_disp = split_disp[0]
+        newline_count = 0
+        for word in split_disp[1:]:
+            if (len(new_disp) >= 25) & (newline_count == 0):
+                separator = '<br>'
+                newline_count = 1
+            else:
+                separator = ' '
+            new_disp = text_template.format(new_disp, separator, word)
+
+        return new_disp
+
+    else:
+        return text
 
 
 def timeseries_lineplot(line_data):
@@ -19,16 +40,17 @@ def timeseries_lineplot(line_data):
     pluralize = {'county': 'counties', 'tract': 'census tracts'}
     fmt_units = pluralize[line_data['fig_aes']['geotype']]
 
-    # number of years to cover: always 2011-2019 (for now)
-    years = [i for i in range(2011, 2020)]
+    # number of years to cover: always 2011-2020 (for now)
+    years = [i for i in range(2011, 2021)]
 
     # measure to use
-    variable = line_data['fig_aes']['label_units']
     center = line_data['fig_aes']['center']
     if center == 'median':
         data = [line_data['years'][y]['median'] for y in years]
     else:
         data = [line_data['years'][y]['mean'] for y in years]
+    variable = line_data['fig_aes']['label_units']
+    legend_name = wrap_text(f'{variable}, statewide {center}')
 
     # make a plot with all the panels
     fig = make_subplots(rows=1, cols=1, x_title='')
@@ -41,7 +63,7 @@ def timeseries_lineplot(line_data):
         go.Scatter(
             y=data,
             x=years,
-            name=f'{variable}, statewide {center}',
+            name=legend_name,
             showlegend=True,
             mode='lines+markers',
             marker_size=10,
@@ -103,8 +125,8 @@ def timeseries_histogram(hist_data):
     pluralize = {'county': 'counties', 'tract': 'census tracts'}
     fmt_units = pluralize[hist_data['fig_aes']['geotype']]
 
-    # number of years to cover: always 2011-2019 (for now)
-    years = [i for i in range(2011, 2020)]
+    # number of years to cover: always 2011-2020 (for now)
+    years = [i for i in range(2011, 2021)]
 
     # make a plot with all the panels
     fig = make_subplots(

--- a/server/protx/data/api/utils/plotly_figures.py
+++ b/server/protx/data/api/utils/plotly_figures.py
@@ -111,6 +111,17 @@ def timeseries_lineplot(line_data):
         rangemode="tozero"
     )
     fig.update_traces(connectgaps=True)
+    fig.update_layout(
+        yaxis = dict(
+            titlefont=dict(size=18),
+            tickfont=dict(size=16)
+        ),
+        legend = dict(
+            font=dict(size=16),
+            traceorder='normal'
+        ),
+        xaxis = dict(tickfont=dict(size=16))
+    )
 
     return(fig)
 
@@ -244,10 +255,13 @@ def timeseries_histogram(hist_data):
         ticktext=hist_data['fig_aes']['bar_labels'],  # same for all plots, so use the last value returned in graph generation loop
     )
     fig.update_yaxes(
-        range=hist_data['fig_aes']['yrange']
+        range=hist_data['fig_aes']['yrange'],
+        tickfont=dict(size=16)
     )
 
     fig.update_xaxes(
-        range=hist_data['fig_aes']['xrange']
+        range=hist_data['fig_aes']['xrange'],
+        tickfont=dict(size=16)
     )
+
     return(fig)


### PR DESCRIPTION
## Overview: ##

## Related Jira tickets: ##

* https://jira.tacc.utexas.edu/browse/COOKS-236
* https://jira.tacc.utexas.edu/browse/COOKS-237
* https://jira.tacc.utexas.edu/browse/COOKS-217
* https://jira.tacc.utexas.edu/browse/COOKS-209

## Summary of Changes: ##

* `plotly_figures.py` now expects data from 2020 for demographics plots
* Plot legends now have line breaks if text strings are greater than 25 characters. Two implementations:
    * `cooks.db` table `display_data` adds a column "DISPLAY_TEXT_PLOT" which includes line breaks (`<br>`) in text strings. Maltreatment plots automatically pull from this field.
    * Demographics plots continue to use the original "DISPLAY_TEXT" field because units are added to the text string when the plot is created, which lengthens the strings and makes the pre-determined breaks poorly positioned. For these plots, a `wrap_text()` method is added in `plotly_figures.py` to handle the line break assignment.
*  Maltreatment plots have an updated figure layout that increases font sizes for axis labels and legends.
* Simple demogrpahics plots have increased font sizes for axis labels and legends. Detailed plots do as well, but margins need some tweaking. Leaving as-is because these plots are not in production.
* I did not change plot aspect ratios because the depend on screen resolution and aspect ratio (for example, current plots look fine on my laptop screen and leave little extra whitespace). But I have notes for how to change this in plotly Python if needed.
* Trafficking is now spelled correctly in the database file and in the color palette.
* The color palette has been expanded by one color to account for a previously missing item (turns out we actually need 10 colors, not 9...).


## Testing Steps: ##

Plots are tested locally in Jupyter notebooks that import the updated modules from this branch, using a local version of the database (`cooks_20220422.db`). 

## UI Photos:

There is a "k" in trafficking now!
![image](https://user-images.githubusercontent.com/3005458/164953939-8a77b3e1-91ac-4ba2-89c9-63285449363c.png)

Line break at the whitespace closest to 25 characters:
![image](https://user-images.githubusercontent.com/3005458/164953980-8ee67a93-92af-44da-864b-6c6bd34ea34a.png)

## Notes: ##
