### PR TITLE
task/COOKS-247: fix onboarding link

### DIFF
--- a/server/portal/apps/onboarding/steps/project_membership.py
+++ b/server/portal/apps/onboarding/steps/project_membership.py
@@ -171,7 +171,7 @@ class ProjectMembershipStep(AbstractStep):
                 ticket_id = event.data["ticket"]
         tracker = self.get_tracker()
         request_text = """Your request for membership on the {project} project has been
-        granted. Please login at {base_url}/onboarding/setup to continue setting up your account.
+        granted. Please login at {base_url}/workbench/onboarding/setup to continue setting up your account.
         """.format(
             project=self.project['title'],
             base_url=settings.WH_BASE_URL


### PR DESCRIPTION
## Overview: ##

 fix onboarding link by pulling in upstream/cepv2 fix.  

## Related Jira tickets: ##

* [COOKS-247](https://jira.tacc.utexas.edu/browse/COOKS-247)

## Testing Steps: ##
1. I think just review code would be sufficient.