### PR TITLE
task/COOKS-265: refactor label on map legend

### DIFF
--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -17,11 +17,7 @@ import 'leaflet/dist/leaflet.css';
 import 'leaflet.markercluster/dist/MarkerCluster.css';
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
 
-import {
-  getMetaData,
-  getMaltreatmentLabel,
-  getObservedFeaturesLabel
-} from '../shared/dataUtils';
+import { getMetaData, getMapLegendLabel } from '../shared/dataUtils';
 import getFeatureStyle from '../shared/mapUtils';
 import IntervalColorScale from '../shared/colorsUtils';
 
@@ -196,10 +192,13 @@ function MainMap({
       setColorScale(intervalColorScale);
 
       if (intervalColorScale) {
-        const label =
-          mapType === 'maltreatment'
-            ? getMaltreatmentLabel(maltreatmentTypes, unit)
-            : getObservedFeaturesLabel(observedFeature, data);
+        const label = getMapLegendLabel(
+          mapType,
+          maltreatmentTypes,
+          observedFeature,
+          unit,
+          data
+        );
 
         const newLegend = L.control({ position: 'bottomright' });
 

--- a/client/src/components/ProTx/components/shared/dataUtils.js
+++ b/client/src/components/ProTx/components/shared/dataUtils.js
@@ -298,7 +298,7 @@ const getMapLegendLabel = (
     return getMaltreatmentLabel(maltreatmentTypes, unit);
   }
   // For demographics (i.e. observed feature)
-  const suffix = unit === `percent` ? ' (Percent)' : ' (Total)';
+  const suffix = unit === `percent` ? ' (Percentages)' : ' (Totals)';
   return getObservedFeaturesLabel(observedFeature, data) + suffix;
 };
 

--- a/client/src/components/ProTx/components/shared/dataUtils.js
+++ b/client/src/components/ProTx/components/shared/dataUtils.js
@@ -283,6 +283,25 @@ const getObservedFeaturesLabel = (selectedObservedFeatureCode, data) => {
   ).DISPLAY_TEXT;
 };
 
+/** Get display label for map
+ *
+ * @returns string
+ */
+const getMapLegendLabel = (
+  mapType,
+  maltreatmentTypes,
+  observedFeature,
+  unit,
+  data
+) => {
+  if (mapType === 'maltreatment') {
+    return getMaltreatmentLabel(maltreatmentTypes, unit);
+  }
+  // For demographics (i.e. observed feature)
+  const suffix = unit === `percent` ? ' (Percent)' : ' (Total)';
+  return getObservedFeaturesLabel(observedFeature, data) + suffix;
+};
+
 export {
   capitalizeString,
   compareSimplifiedValueType,
@@ -292,5 +311,6 @@ export {
   getFipsIdName,
   getMaltreatmentTypeNames,
   getMaltreatmentLabel,
-  getObservedFeaturesLabel
+  getObservedFeaturesLabel,
+  getMapLegendLabel
 };


### PR DESCRIPTION
## Overview: ##

Refactor the label on the map legend.

## Related Jira tickets: ##

* [COOKS-265](https://jira.tacc.utexas.edu/browse/COOKS-265)

## Testing Steps: ##
1. Go to https://cep.dev/protx/analytics
2. Go to https://cep.dev/protx/demographics
3. In https://cep.dev/protx/demographics, you can switch between percent and total and note change
4. Click on a county just to get a feel for how things look.

## UI Photos:

![Screen Shot 2022-05-13 at 4 24 23 PM](https://user-images.githubusercontent.com/8287580/168391974-4659855a-05c1-475a-bfca-523f6078aea9.png)
![Screen Shot 2022-05-13 at 4 24 15 PM](https://user-images.githubusercontent.com/8287580/168391977-9a6b64a1-9d37-4143-b664-a66faf0fc1e0.png)
![Screen Shot 2022-05-13 at 4 25 13 PM](https://user-images.githubusercontent.com/8287580/168391966-5d6a8cfa-c91b-4bfd-b04f-12c26e826dcd.png)

## Notes: ##
- [ ] gonna clarify with Tracy/Vera in the meeting if this is how they want things to look.
