### PR TITLE
Task/COOKS-266: Make default selector for demographics population 17 years and under.

### DIFF
--- a/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
+++ b/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
@@ -28,7 +28,7 @@ function DashboardDisplay() {
   const [maltreatmentTypes, setMaltreatmentTypes] = useState(
     PRESELECTED_MALTREATMENT_CATEGORIES
   );
-  const [observedFeature, setObservedFeature] = useState('CROWD');
+  const [observedFeature, setObservedFeature] = useState('AGE17');
   const [year, setYear] = useState('2019');
   const [selectedGeographicFeature, setSelectedGeographicFeature] = useState(
     ''


### PR DESCRIPTION
## Overview: ##
Made default demographics selection to 'Population 17 years and under'

## Related Jira tickets: ##

* [COOKS-266](https://jira.tacc.utexas.edu/browse/COOKS-266)

## Summary of Changes: ##
Change default selection.

## Testing Steps: ##
1. Ensure that "Population 17 years and under" is selected by default in demographics route.

## UI Photos:

## Notes: ##
