### PR TITLE
Task/COOKS-264: Add 2 default checked map layers.

### DIFF
--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -254,8 +254,11 @@ function MainMap({
             const matchingMeta = resourcesMeta.find(
               r => r.NAICS_CODE === parseInt(point.NAICS_CODE, 10)
             );
-            if (matchingMeta.DESCRIPTION === 'Child and Youth Services' || matchingMeta.DESCRIPTION === 'Cook Children\'s Locations') {
-            // if (point.NAICS_CODE === 9999 || point.NAICS_CODE === 6241) {
+            if (
+              matchingMeta.DESCRIPTION === 'Child and Youth Services' ||
+              matchingMeta.DESCRIPTION === "Cook Children's Locations"
+            ) {
+              // if (point.NAICS_CODE === 9999 || point.NAICS_CODE === 6241) {
               resourcesClusterGroups[point.NAICS_CODE].addTo(map);
             }
           }

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -96,7 +96,12 @@ function MainMap({
       if (newZoomLevel >= RESOURCE_ZOOM_LEVEL) {
         currentLayerControl.expand();
         refResourceLayers.current.forEach(resourceLayer => {
-          currentMap.addLayer(resourceLayer.layer);
+          if (
+            resourceLayer.label === 'Child and Youth Services' ||
+            resourceLayer.label === "Cook Children's Locations"
+          ) {
+            currentMap.addLayer(resourceLayer.layer);
+          }
         });
       } else {
         currentLayerControl.collapse();
@@ -251,16 +256,6 @@ function MainMap({
             resourcesClusterGroups[point.NAICS_CODE] = L.markerClusterGroup({
               showCoverageOnHover: false
             });
-            const matchingMeta = resourcesMeta.find(
-              r => r.NAICS_CODE === parseInt(point.NAICS_CODE, 10)
-            );
-            if (
-              matchingMeta.DESCRIPTION === 'Child and Youth Services' ||
-              matchingMeta.DESCRIPTION === "Cook Children's Locations"
-            ) {
-              // if (point.NAICS_CODE === 9999 || point.NAICS_CODE === 6241) {
-              resourcesClusterGroups[point.NAICS_CODE].addTo(map);
-            }
           }
 
           const marker = L.marker(L.latLng(point.LATITUDE, point.LONGITUDE), {

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -251,6 +251,13 @@ function MainMap({
             resourcesClusterGroups[point.NAICS_CODE] = L.markerClusterGroup({
               showCoverageOnHover: false
             });
+            const matchingMeta = resourcesMeta.find(
+              r => r.NAICS_CODE === parseInt(point.NAICS_CODE, 10)
+            );
+            if (matchingMeta.DESCRIPTION === 'Child and Youth Services' || matchingMeta.DESCRIPTION === 'Cook Children\'s Locations') {
+            // if (point.NAICS_CODE === 9999 || point.NAICS_CODE === 6241) {
+              resourcesClusterGroups[point.NAICS_CODE].addTo(map);
+            }
           }
 
           const marker = L.marker(L.latLng(point.LATITUDE, point.LONGITUDE), {


### PR DESCRIPTION
## Overview: ##
Set Child and Youth Services and Cook Children's Locations on by default.

## Related Jira tickets: ##

* [COOKS-264](https://jira.tacc.utexas.edu/browse/COOKS-264)

## Summary of Changes: ##
Changed `MainMap.js`.

## Testing Steps: ##
1. Ensure that Child and Youth Services and Cook Children's Locations are on by default.

## UI Photos:

## Notes: ##
I wasn't sure if I should check directly with the `NAICS_CODE` or through the resource description (requires extra check).