### PR TITLE
Task/legend linebreaks review addendums

### DIFF
--- a/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
+++ b/client/src/components/ProTx/components/dashboard/DashboardDisplay.js
@@ -13,6 +13,7 @@ function DashboardDisplay() {
   // TODO: control of this state (county, year, feature etc) should be moved to redux/sagas (https://jira.tacc.utexas.edu/browse/COOKS-55)
   const [mapType, setMapType] = useState('maltreatment');
   const [geography, setGeography] = useState('county');
+  const defaultYear = '2020';
   const PRESELECTED_MALTREATMENT_CATEGORIES = [
     'ABAN',
     'EMAB',
@@ -29,7 +30,7 @@ function DashboardDisplay() {
     PRESELECTED_MALTREATMENT_CATEGORIES
   );
   const [observedFeature, setObservedFeature] = useState('CROWD');
-  const [year, setYear] = useState('2019');
+  const [year, setYear] = useState(defaultYear);
   const [selectedGeographicFeature, setSelectedGeographicFeature] = useState(
     ''
   );
@@ -51,7 +52,7 @@ function DashboardDisplay() {
       setUnit('rate_per_100k_under17');
     } else {
       // observedFeatures (i.e. Demographic Features) and analytics
-      setYear('2019'); // observedFeatures (i.e. Demographic Features) only has 2019 data.
+      setYear(defaultYear); // observedFeatures (i.e. Demographic Features) only has 2019 data.
       setGeography('county');
       setUnit('percent');
     }
@@ -169,7 +170,7 @@ function DashboardDisplay() {
                       mapType={mapType}
                       geography={geography}
                       observedFeature={observedFeature}
-                      year="2019"
+                      year={defaultYear}
                       selectedGeographicFeature={selectedGeographicFeature}
                       data={data}
                       unit={unit}

--- a/client/src/components/ProTx/components/data/meta.js
+++ b/client/src/components/ProTx/components/data/meta.js
@@ -1,4 +1,5 @@
 export const SUPPORTED_YEARS = [
+  '2020',
   '2019',
   '2018',
   '2017',

--- a/client/src/components/ProTx/components/maps/MainMap.js
+++ b/client/src/components/ProTx/components/maps/MainMap.js
@@ -17,11 +17,7 @@ import 'leaflet/dist/leaflet.css';
 import 'leaflet.markercluster/dist/MarkerCluster.css';
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
 
-import {
-  getMetaData,
-  getMaltreatmentLabel,
-  getObservedFeaturesLabel
-} from '../shared/dataUtils';
+import { getMetaData, getMapLegendLabel } from '../shared/dataUtils';
 import getFeatureStyle from '../shared/mapUtils';
 import IntervalColorScale from '../shared/colorsUtils';
 
@@ -196,10 +192,13 @@ function MainMap({
       setColorScale(intervalColorScale);
 
       if (intervalColorScale) {
-        const label =
-          mapType === 'maltreatment'
-            ? getMaltreatmentLabel(maltreatmentTypes, unit)
-            : getObservedFeaturesLabel(observedFeature, data);
+        const label = getMapLegendLabel(
+          mapType,
+          maltreatmentTypes,
+          observedFeature,
+          unit,
+          data
+        );
 
         const newLegend = L.control({ position: 'bottomright' });
 

--- a/client/src/components/ProTx/components/shared/dataUtils.js
+++ b/client/src/components/ProTx/components/shared/dataUtils.js
@@ -283,6 +283,25 @@ const getObservedFeaturesLabel = (selectedObservedFeatureCode, data) => {
   ).DISPLAY_TEXT;
 };
 
+/** Get display label for map
+ *
+ * @returns string
+ */
+const getMapLegendLabel = (
+  mapType,
+  maltreatmentTypes,
+  observedFeature,
+  unit,
+  data
+) => {
+  if (mapType === 'maltreatment') {
+    return getMaltreatmentLabel(maltreatmentTypes, unit);
+  }
+  // For demographics (i.e. observed feature)
+  const suffix = unit === `percent` ? ' (Percentages)' : ' (Totals)';
+  return getObservedFeaturesLabel(observedFeature, data) + suffix;
+};
+
 export {
   capitalizeString,
   compareSimplifiedValueType,
@@ -292,5 +311,6 @@ export {
   getFipsIdName,
   getMaltreatmentTypeNames,
   getMaltreatmentLabel,
-  getObservedFeaturesLabel
+  getObservedFeaturesLabel,
+  getMapLegendLabel
 };

--- a/server/portal/apps/onboarding/steps/project_membership.py
+++ b/server/portal/apps/onboarding/steps/project_membership.py
@@ -171,7 +171,7 @@ class ProjectMembershipStep(AbstractStep):
                 ticket_id = event.data["ticket"]
         tracker = self.get_tracker()
         request_text = """Your request for membership on the {project} project has been
-        granted. Please login at {base_url}/onboarding/setup to continue setting up your account.
+        granted. Please login at {base_url}/workbench/onboarding/setup to continue setting up your account.
         """.format(
             project=self.project['title'],
             base_url=settings.WH_BASE_URL


### PR DESCRIPTION
## Overview: ##

Some added tweaks to improve the review of the legend-linebreaks Issue from Kelly.

Still throwing an error on the maltreatment data query response (same as in the parent branch `legend-linebreaks`):

```
[DJANGO] ERROR 2022-05-23 18:49:08,728 UTC log django.request.log_response:228: Internal Server Error: /api/protx/maltreatment-plot-distribution/
core_portal_django         | Traceback (most recent call last):
core_portal_django         |   File "/opt/pysetup/.venv/lib/python3.7/site-packages/django/core/handlers/exception.py", line 34, in inner
core_portal_django         |     response = get_response(request)
core_portal_django         |   File "/opt/pysetup/.venv/lib/python3.7/site-packages/django/core/handlers/base.py", line 115, in _get_response
core_portal_django         |     response = self.process_exception_by_middleware(e, request)
core_portal_django         |   File "/opt/pysetup/.venv/lib/python3.7/site-packages/django/core/handlers/base.py", line 113, in _get_response
core_portal_django         |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
core_portal_django         |   File "/srv/www/portal/server/protx/data/api/decorators.py", line 20, in wrapper
core_portal_django         |     return function(*args, **kwargs)
core_portal_nginx          | 172.18.0.1 - - [23/May/2022:18:49:08 +0000] "PATCH /api/protx/maltreatment-plot-distribution/ HTTP/2.0" 500 111266 "https://cep.dev/protx/maltreatment" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.64 Safari/537.36" "-"
core_portal_django         |   File "/opt/pysetup/.venv/lib/python3.7/site-packages/django/utils/decorators.py", line 142, in _wrapped_view
core_portal_django         |     response = view_func(request, *args, **kwargs)
core_portal_django         |   File "/srv/www/portal/server/protx/data/api/views.py", line 193, in get_maltreatment_distribution_plot_data
core_portal_django         |     result = maltreatment.maltreatment_plot_figure(area=area, selectedArea=selectedArea, geoid=geoid, variables=variables, unit=unit)
core_portal_django         |   File "/srv/www/portal/server/protx/data/api/maltreatment.py", line 138, in maltreatment_plot_figure
core_portal_django         |     maltrt_data = query_return(user_select_data, db_conn)
core_portal_django         |   File "/srv/www/portal/server/protx/data/api/maltreatment.py", line 56, in query_return
core_portal_django         |     maltrt_query_fmt = maltrt_query.format(**user_selection)
core_portal_django         | KeyError: 'variable'
core_portal_django         | [DJANGO] ERROR 2022-05-23 18:49:08,730 UTC basehttp django.server.log_message:154: "PATCH /api/protx/maltreatment-plot-distribution/ HTTP/1.0" 500 111266
```

