### PR TITLE
Hotfix: Handle no maltreatment data

### DIFF
--- a/client/src/components/ProTx/components/shared/dataUtils.js
+++ b/client/src/components/ProTx/components/shared/dataUtils.js
@@ -125,6 +125,9 @@ const getMaltreatmentMetaData = (
     const values = Object.values(aggregrateValues).map(x => +x);
     if (values.length) {
       meta = { min: Math.min(...values), max: Math.max(...values) };
+    } else {
+      // no values were found
+      return null;
     }
   }
   if (meta.max < 100.0000001 && meta.min > 99.9999999) {


### PR DESCRIPTION
## Overview: ##

Recognize when no values were found for maltreatment.  For example, a user selects a year and a single maltreatment type where there is no data for that year, we need to recognize that.


## Testing Steps: ##
1. Select Sex Trafficking and year 2011.
