### PR TITLE
Task/COOKS-273: Change download button style.

### DIFF
--- a/client/src/components/ProTx/components/dashboard/DisplaySelectors.js
+++ b/client/src/components/ProTx/components/dashboard/DisplaySelectors.js
@@ -233,8 +233,8 @@ function DisplaySelectors({
       </div>
 
       {selectedGeographicFeature && (
-        <Button onClick={downloadResources} download>
-          <i className="icon-download" /> <span>Download</span>
+        <Button onClick={downloadResources} color="primary" size="sm" styleName="download-btn" download>
+          Download
         </Button>
       )}
     </div>

--- a/client/src/components/ProTx/components/dashboard/DisplaySelectors.js
+++ b/client/src/components/ProTx/components/dashboard/DisplaySelectors.js
@@ -233,7 +233,13 @@ function DisplaySelectors({
       </div>
 
       {selectedGeographicFeature && (
-        <Button onClick={downloadResources} color="primary" size="sm" styleName="download-btn" download>
+        <Button
+          onClick={downloadResources}
+          color="primary"
+          size="sm"
+          styleName="download-btn"
+          download
+        >
           Download
         </Button>
       )}

--- a/client/src/components/ProTx/components/dashboard/DisplaySelectors.module.scss
+++ b/client/src/components/ProTx/components/dashboard/DisplaySelectors.module.scss
@@ -21,6 +21,17 @@
   align-items: center;
 }
 
+.download-btn {
+  background-color: var(--global-color-accent--normal);
+  border-color: var(--global-color-accent--alt);
+  border-radius: 0;
+}
+
+.download-btn:hover {
+  background-color: var(--global-color-accent--weak);
+  border-color: var(--global-color-accent--weak);
+}
+
 .radio-container label {
   margin-bottom: 0;
   padding-right: 10px;

--- a/client/src/components/ProTx/components/maps/ProtxColors.css
+++ b/client/src/components/ProTx/components/maps/ProtxColors.css
@@ -3,6 +3,7 @@
 /* Portal Variable Overwrites */
 #react-root {
     --global-color-accent--normal: #924e8c;
+    --global-color-accent--weak: #924e8c80;
 }
 
 /* CHOROPLETH MAP */


### PR DESCRIPTION
## Overview: ##

## Related Jira tickets: ##

* [COOKS-273](https://jira.tacc.utexas.edu/browse/COOKS-273)

## Summary of Changes: ##
- [X] no icon
- [X] match font of "value percentages rate per 100K"
  - The font for that was 1rem, but it appeared too large with the button background. So, I just kept what the `sm` button option provided.
- [X] make button smaller
- [X] change button color

## Testing Steps: ##
1. Select an area on map for download to see.
2. Ensure that the button style matches the one in the video.

## UI Photos:

https://user-images.githubusercontent.com/9425579/174329752-81463769-95fa-4624-9b3a-bf27af41b93c.mp4

## Notes: ##
